### PR TITLE
Support parsing without embedded HTML

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,4 +39,4 @@ mod puncttable;
 mod utils;
 
 pub use passes::Parser;
-pub use parse::{Alignment, Event, Tag, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+pub use parse::{Alignment, Event, Tag, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES, OPTION_DISABLE_HTML};

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ extern crate getopts;
 extern crate pulldown_cmark;
 
 use pulldown_cmark::Parser;
-use pulldown_cmark::{Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+use pulldown_cmark::{Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES, OPTION_DISABLE_HTML};
 use pulldown_cmark::html;
 
 use std::env;
@@ -206,6 +206,7 @@ pub fn main() {
     opts.optflag("e", "events", "print event sequence instead of rendering");
     opts.optflag("T", "enable-tables", "enable GitHub-style tables");
     opts.optflag("F", "enable-footnotes", "enable Hoedown-style footnotes");
+    opts.optflag("H", "disable-html", "disable embedded HTML");
     opts.optopt("s", "spec", "run tests from spec file", "FILE");
     opts.optopt("b", "bench", "run benchmark", "FILE");
     let matches = match opts.parse(&args[1..]) {
@@ -234,6 +235,9 @@ pub fn main() {
     }
     if matches.opt_present("enable-footnotes") {
         opts.insert(OPTION_ENABLE_FOOTNOTES);
+    }
+    if matches.opt_present("disable-html") {
+        opts.insert(OPTION_DISABLE_HTML);
     }
     if let Some(filename) = matches.opt_str("spec") {
         run_spec(&read_file(&filename).replace("→", "\t"), &matches.free, opts);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -144,6 +144,7 @@ bitflags! {
         const OPTION_FIRST_PASS = 1 << 0;
         const OPTION_ENABLE_TABLES = 1 << 1;
         const OPTION_ENABLE_FOOTNOTES = 1 << 2;
+        const OPTION_DISABLE_HTML = 1 << 3;
     }
 }
 
@@ -757,6 +758,10 @@ impl<'a> RawParser<'a> {
     }
 
     fn is_html_block(&self, data: &str) -> bool {
+        if self.opts.contains(OPTION_DISABLE_HTML) {
+            return false;
+        }
+
         let (n_tag, tag) = self.scan_html_block_tag(data);
         (n_tag > 0 && is_html_tag(tag)) ||
                 data.starts_with("<?") ||
@@ -1473,6 +1478,10 @@ impl<'a> RawParser<'a> {
     }
 
     fn scan_inline_html(&self, data: &str) -> usize {
+        if self.opts.contains(OPTION_DISABLE_HTML) {
+            return 0;
+        }
+
         let n = self.scan_html_tag(data);
         if n != 0 { return n; }
         let n = self.scan_html_comment(data);

--- a/tests/disable_html.rs
+++ b/tests/disable_html.rs
@@ -1,0 +1,212 @@
+// Tests for OPTION_DISABLE_HTML
+
+extern crate pulldown_cmark;
+
+use pulldown_cmark::{Parser, html, OPTION_DISABLE_HTML};
+
+#[test]
+fn disable_html_test_1() {
+    let original = r##"Little header
+
+<script type="text/js">
+function some_func() {
+console.log("teeeest");
+}
+
+
+function another_func() {
+console.log("fooooo");
+}
+</script>"##;
+    let expected = r##"<p>Little header</p>
+<p>&lt;script type=&quot;text/js&quot;&gt;
+function some_func() {
+console.log(&quot;teeeest&quot;);
+}</p>
+<p>function another_func() {
+console.log(&quot;fooooo&quot;);
+}
+&lt;/script&gt;</p>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn disable_html_test_2() {
+    let original = r##"Little header
+
+<script
+type="text/js">
+function some_func() {
+console.log("teeeest");
+}
+
+
+function another_func() {
+console.log("fooooo");
+}
+</script>"##;
+    let expected = r##"<p>Little header</p>
+<p>&lt;script
+type=&quot;text/js&quot;&gt;
+function some_func() {
+console.log(&quot;teeeest&quot;);
+}</p>
+<p>function another_func() {
+console.log(&quot;fooooo&quot;);
+}
+&lt;/script&gt;</p>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn disable_html_test_3() {
+    let original = r##"Little header
+
+<?
+<div></div>
+<p>Useful</p>
+?>"##;
+    let expected = r##"<p>Little header</p>
+<p>&lt;?
+&lt;div&gt;&lt;/div&gt;
+&lt;p&gt;Useful&lt;/p&gt;
+?&gt;</p>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn disable_html_test_4() {
+    let original = r##"Little header
+
+<!--
+<div></div>
+<p>Useful</p>
+-->"##;
+    let expected = r##"<p>Little header</p>
+<p>&lt;!--
+&lt;div&gt;&lt;/div&gt;
+&lt;p&gt;Useful&lt;/p&gt;
+--&gt;</p>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn disable_html_test_5() {
+    let original = r##"Little header
+
+<![CDATA[
+<div></div>
+<p>Useful</p>
+]]>"##;
+    let expected = r##"<p>Little header</p>
+<p>&lt;![CDATA[
+&lt;div&gt;&lt;/div&gt;
+&lt;p&gt;Useful&lt;/p&gt;
+]]&gt;</p>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn disable_html_test_6() {
+    let original = r##"Little header
+
+<!X
+Some things are here...
+>"##;
+    let expected = r##"<p>Little header</p>
+<p>&lt;!X
+Some things are here...</p>
+<blockquote>
+</blockquote>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn disable_html_test_7() {
+    let original = r##"Little header
+-----------
+
+<script>
+function some_func() {
+console.log("teeeest");
+}
+
+
+function another_func() {
+console.log("fooooo");
+}
+</script>"##;
+    let expected = r##"<h2>Little header</h2>
+<p>&lt;script&gt;
+function some_func() {
+console.log(&quot;teeeest&quot;);
+}</p>
+<p>function another_func() {
+console.log(&quot;fooooo&quot;);
+}
+&lt;/script&gt;</p>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn disable_html_test_8() {
+    let original = r##"<a href=\"this *should* be parsed\">Not a link</a>"##;
+    let expected = r##"<p>&lt;a href=&quot;this <em>should</em> be parsed&quot;&gt;Not a link&lt;/a&gt;</p>
+"##;
+
+    let mut s = String::new();
+
+    let p = Parser::new_ext(&original, OPTION_DISABLE_HTML);
+    html::push_html(&mut s, p);
+
+    assert_eq!(expected, s);
+}


### PR DESCRIPTION
This patch adds an option flag, `OPTION_DISABLE_HTML`, which configures the parser to avoid recognizing embedded HTML tags in the input. Thus, all would-be HTML in the input ends up escaped in the output: `<malicious-tag>` -> `&lt;malicious-tag&gt;`.

This is useful when accepting Markdown input from untrusted users as a simpler alternative to whitelisting of HTML.