### PR TITLE
Inline code in table rows now render backslashes properly

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -935,9 +935,16 @@ impl<'a> RawParser<'a> {
             return self.end();
         }
         let mut n = 0;
+        let mut in_code = false;
         while i < limit {
             let c = bytes[i];
-            if c == b'\\' && i + 1 < limit && bytes[i + 1] == b'|' {
+            if c == b'`' {
+                in_code = !in_code;
+            }
+            if in_code {
+                i += 1;
+                continue;
+            } else if c == b'\\' && i + 1 < limit && bytes[i + 1] == b'|' {
                 i += 2;
                 continue;
             } else if c == b'|' {


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/mdBook/issues/637
Fixes https://github.com/google/pulldown-cmark/issues/127

I have tested with both rustdoc and and mdBook
`cargo test` still fails the same 56 spec tests.

## Changes

If you put inline code in a table cell using code backticks (<code>\`</code>) then *everything* within those backticks is treated the same way it is *outside* tables.

The main effect is that having a `|` in inline code now renders correctly.

### Examples

```markdown
|           Regex             |     Matches     |
|-----------------------------|-----------------|
|`foo-(1|[3-5])|bar-([39]|39)`|`foo-1`, `bar-39`|
```
#### Old Rendering

<table><thead><tr><td>           Regex             </td><td>     Matches     </td></tr></thead><tr><td>`foo-(1</td><td>[3-5])</td><td>bar-([39]</td><td>39)`</td><td><code>foo-1</code>, <code>bar-39</code></td></tr></table>

#### New Rendering

<table><thead><tr><td>           Regex             </td><td>     Matches     </td></tr></thead><tr><td><code>foo-(1|[3-5])|bar-([39]|39)</code></td><td><code>foo-1</code>, <code>bar-39</code></td></tr></table>

<hr />

### <code>\`</code> with an escape `\` before pipes

This one doesn't change (which is to be expected as `|` doesn't need an escape in inline code)

```markdown
|           Regex             |     Matches     |
|-----------------------------|-----------------|
|`foo-(1\|[3-5])\|bar-([39]\|39)`|`foo-1`, `bar-39`|
```
<table><thead><tr><td>           Regex             </td><td>     Matches     </td></tr></thead><tr><td><code>foo-(1\|[3-5])\|bar-([39]\|39)</code></td><td><code>foo-1</code>, <code>bar-39</code></td></tr></table>