### PR TITLE
Update bitflags to v1 and publish v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark"
-version = "0.1.2"
+version = "0.2.0"
 authors = [ "Raph Levien <raph@google.com>" ]
 license = "MIT"
 description = "A pull parser for CommonMark"
@@ -15,7 +15,7 @@ required-features = ["getopts"]
 doc = false
 
 [dependencies]
-bitflags = "0.9"
+bitflags = "1"
 getopts = { version = "0.2", optional = true }
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -73,13 +73,13 @@ fn generate_tests_from_spec() {
         let original = r##"{original}"##;
         let expected = r##"{expected}"##;
 
-        use pulldown_cmark::{{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES}};
+        use pulldown_cmark::{{Parser, html, Options}};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,4 +39,4 @@ mod puncttable;
 mod utils;
 
 pub use passes::Parser;
-pub use parse::{Alignment, Event, Tag, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+pub use parse::{Alignment, Event, Tag, Options};

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ extern crate getopts;
 extern crate pulldown_cmark;
 
 use pulldown_cmark::Parser;
-use pulldown_cmark::{Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+use pulldown_cmark::Options;
 use pulldown_cmark::html;
 
 use std::env;
@@ -230,10 +230,10 @@ pub fn main() {
     }
     let mut opts = Options::empty();
     if matches.opt_present("enable-tables") {
-        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(Options::ENABLE_TABLES);
     }
     if matches.opt_present("enable-footnotes") {
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
     }
     if let Some(filename) = matches.opt_str("spec") {
         run_spec(&read_file(&filename).replace("→", "\t"), &matches.free, opts);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -141,9 +141,9 @@ pub enum Alignment {
 
 bitflags! {
     pub struct Options: u32 {
-        const OPTION_FIRST_PASS = 1 << 0;
-        const OPTION_ENABLE_TABLES = 1 << 1;
-        const OPTION_ENABLE_FOOTNOTES = 1 << 2;
+        const FIRST_PASS = 1 << 0;
+        const ENABLE_TABLES = 1 << 1;
+        const ENABLE_FOOTNOTES = 1 << 2;
     }
 }
 
@@ -204,7 +204,7 @@ impl<'a> RawParser<'a> {
     }
 
     fn init_active(&mut self) {
-        if self.opts.contains(OPTION_FIRST_PASS) {
+        if self.opts.contains(Options::FIRST_PASS) {
             self.active_tab[b'\n' as usize] = 1
         } else {
             for &c in b"\x00\t\n\r_\\&*[!`<" {
@@ -484,7 +484,7 @@ impl<'a> RawParser<'a> {
                     }
                 }
                 b'[' => {
-                    if self.opts.contains(OPTION_ENABLE_FOOTNOTES) {
+                    if self.opts.contains(Options::ENABLE_FOOTNOTES) {
                         if let Some((name, n)) = self.parse_footnote_definition(tail) {
                             if self.containers.last() == Some(&Container::FootnoteDefinition) {
                                 return Some(self.end());
@@ -521,7 +521,7 @@ impl<'a> RawParser<'a> {
                     self.state = State::Inline;
                     return self.start(Tag::Header(level), i, next);
                 }
-                if self.opts.contains(OPTION_ENABLE_TABLES) {
+                if self.opts.contains(Options::ENABLE_TABLES) {
                     let (n, cols) = scan_table_head(&self.text[i..]);
                     if n != 0 {
                         let next = i + n;
@@ -541,7 +541,7 @@ impl<'a> RawParser<'a> {
     }
 
     fn start_table_head(&mut self) -> Event<'a> {
-        assert!(self.opts.contains(OPTION_ENABLE_TABLES));
+        assert!(self.opts.contains(Options::ENABLE_TABLES));
         if let State::TableHead(limit, next) = self.state {
             self.state = State::TableRow;
             return self.start(Tag::TableHead, limit, next);
@@ -551,7 +551,7 @@ impl<'a> RawParser<'a> {
     }
 
     fn start_table_body(&mut self) -> Event<'a> {
-        assert!(self.opts.contains(OPTION_ENABLE_TABLES));
+        assert!(self.opts.contains(Options::ENABLE_TABLES));
         let (off, _) = match self.scan_containers(&self.text[self.off ..]) {
             (n, true, space) => (self.off + n, space),
             _ => {
@@ -920,7 +920,7 @@ impl<'a> RawParser<'a> {
     }
 
     fn next_table_cell(&mut self) -> Event<'a> {
-        assert!(self.opts.contains(OPTION_ENABLE_TABLES));
+        assert!(self.opts.contains(Options::ENABLE_TABLES));
         let bytes   = self.text.as_bytes();
         let mut beg = self.off + scan_whitespace_no_nl(&self.text[self.off ..]);
         let mut i   = beg;
@@ -1021,7 +1021,7 @@ impl<'a> RawParser<'a> {
             b'&' => self.char_entity(),
             b'_' |
             b'*' => self.char_emphasis(),
-            b'[' if self.opts.contains(OPTION_ENABLE_FOOTNOTES) => self.char_link_footnote(),
+            b'[' if self.opts.contains(Options::ENABLE_FOOTNOTES) => self.char_link_footnote(),
             b'[' | b'!' => self.char_link(),
             b'`' => self.char_backtick(),
             b'<' => self.char_lt(),
@@ -1140,7 +1140,7 @@ impl<'a> RawParser<'a> {
                     i += 1;
                 }
             } else if c2 == b'[' {
-                if self.opts.contains(OPTION_ENABLE_FOOTNOTES) {
+                if self.opts.contains(Options::ENABLE_FOOTNOTES) {
                     if let Some((_, n)) = self.parse_footnote(&self.text[i..limit]) {
                         i += n;
                         continue;
@@ -1352,7 +1352,7 @@ impl<'a> RawParser<'a> {
                     }
                 }
                 b'[' => {
-                    if self.opts.contains(OPTION_ENABLE_FOOTNOTES) && self.parse_footnote(&data[i..]).is_some() {
+                    if self.opts.contains(Options::ENABLE_FOOTNOTES) && self.parse_footnote(&data[i..]).is_some() {
                         return false;
                     }
                     if self.parse_link(&data[i..], true).is_some() { return true; }
@@ -1384,7 +1384,7 @@ impl<'a> RawParser<'a> {
     // # Footnotes
 
     fn parse_footnote_definition<'b>(&self, data: &'b str) -> Option<(&'b str, usize)> {
-        assert!(self.opts.contains(OPTION_ENABLE_FOOTNOTES));
+        assert!(self.opts.contains(Options::ENABLE_FOOTNOTES));
         self.parse_footnote(data).and_then(|(name, len)| {
             let n_colon = scan_ch(&data[len ..], b':');
             if n_colon == 0 {
@@ -1404,7 +1404,7 @@ impl<'a> RawParser<'a> {
     }
 
     fn char_link_footnote(&mut self) -> Option<Event<'a>> {
-        assert!(self.opts.contains(OPTION_ENABLE_FOOTNOTES));
+        assert!(self.opts.contains(Options::ENABLE_FOOTNOTES));
         if let Some((name, end)) = self.parse_footnote(&self.text[self.off .. self.limit()]) {
             self.off += end;
             Some(Event::FootnoteReference(Cow::Borrowed(name)))
@@ -1414,14 +1414,14 @@ impl<'a> RawParser<'a> {
     }
 
     fn parse_footnote<'b>(&self, data: &'b str) -> Option<(&'b str, usize)> {
-        assert!(self.opts.contains(OPTION_ENABLE_FOOTNOTES));
+        assert!(self.opts.contains(Options::ENABLE_FOOTNOTES));
         let (n_footnote, text_beg, text_end) = self.scan_footnote_label(data);
         if n_footnote == 0 { return None; }
         Some((&data[text_beg..text_end], n_footnote))
     }
 
     fn scan_footnote_label(&self, data: &str) -> (usize, usize, usize) {
-        assert!(self.opts.contains(OPTION_ENABLE_FOOTNOTES));
+        assert!(self.opts.contains(Options::ENABLE_FOOTNOTES));
         let mut i = scan_ch(data, b'[');
         if i == 0 { return (0, 0, 0); }
         if i >= data.len() || data.as_bytes()[i] != b'^' { return (0, 0, 0); }

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -20,7 +20,7 @@
 
 //! Main public pull parse interface, running two passes over input.
 
-use parse::{RawParser, Event, Tag, Options, OPTION_FIRST_PASS};
+use parse::{RawParser, Event, Tag, Options};
 use std::collections::HashSet;
 
 pub struct Parser<'a> {
@@ -45,9 +45,9 @@ impl<'a> Parser<'a> {
     pub fn new_with_broken_link_callback(text: &'a str, mut opts: Options,
             callback: Option<&'a Fn(&str, &str) -> Option<(String, String)>>)
             -> Parser<'a>  {
-        opts.remove(OPTION_FIRST_PASS);
+        opts.remove(Options::FIRST_PASS);
         // first pass, collecting info
-        let first_opts = opts | OPTION_FIRST_PASS;
+        let first_opts = opts | Options::FIRST_PASS;
         let mut first = RawParser::new(text, first_opts);
         while first.next().is_some() { }
         let info = first.get_info();

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -16,13 +16,13 @@ extern crate pulldown_cmark;
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -46,13 +46,13 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -79,13 +79,13 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -105,13 +105,13 @@ I had largely given over my inquiries into what Professor Angell called the "Cth
 <p>I had largely given over my inquiries into what Professor Angell called the &quot;Cthulhu Cult&quot;, and was visiting a learned friend in Paterson, New Jersey; the curator of a local museum and a mineralogist of note. Examining one day the reserve specimens roughly set on the storage shelves in a rear room of the museum, my eye was caught by an odd picture in one of the old papers spread beneath the stones. It was the Sydney Bulletin I have mentioned, for my friend had wide affiliations in all conceivable foreign parts; and the picture was a half-tone cut of a hideous stone image almost identical with that which Legrasse had found in the swamp.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -135,13 +135,13 @@ If a woodchuck could chuck wood.
 <h1>Forms of entertainment that aren't childish</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -166,13 +166,13 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
 <p>As such, we can guarantee that the non-childish forms of entertainment are probably more entertaining to adults, since, having had a whole childhood doing the childish ones, the non-childish ones are merely the ones that haven't gotten boring yet.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -211,13 +211,13 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -239,13 +239,13 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -12,13 +12,13 @@ extern crate pulldown_cmark;
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -34,13 +34,13 @@ extern crate pulldown_cmark;
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -58,13 +58,13 @@ extern crate pulldown_cmark;
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -86,13 +86,13 @@ extern crate pulldown_cmark;
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -115,13 +115,13 @@ extern crate pulldown_cmark;
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -139,13 +139,13 @@ extern crate pulldown_cmark;
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -165,13 +165,13 @@ extern crate pulldown_cmark;
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -189,13 +189,13 @@ bar
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -222,13 +222,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -243,13 +243,13 @@ bar
         let expected = r##"<h1>Foo</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -264,13 +264,13 @@ bar
         let expected = r##"<hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -289,13 +289,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -314,13 +314,13 @@ ___
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -335,13 +335,13 @@ ___
         let expected = r##"<p>+++</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -356,13 +356,13 @@ ___
         let expected = r##"<p>===</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -381,13 +381,13 @@ __
 __</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -406,13 +406,13 @@ __</p>
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -428,13 +428,13 @@ __</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -451,13 +451,13 @@ __</p>
 ***</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -472,13 +472,13 @@ __</p>
         let expected = r##"<hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -493,13 +493,13 @@ __</p>
         let expected = r##"<hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -514,13 +514,13 @@ __</p>
         let expected = r##"<hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -535,13 +535,13 @@ __</p>
         let expected = r##"<hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -556,13 +556,13 @@ __</p>
         let expected = r##"<hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -583,13 +583,13 @@ a------
 <p>---a---</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -604,13 +604,13 @@ a------
         let expected = r##"<p><em>-</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -633,13 +633,13 @@ a------
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -658,13 +658,13 @@ bar
 <p>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -682,13 +682,13 @@ bar
 <p>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -711,13 +711,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -738,13 +738,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -769,13 +769,13 @@ bar
 <h6>foo</h6>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -790,13 +790,13 @@ bar
         let expected = r##"<p>####### foo</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -814,13 +814,13 @@ bar
 <p>#hashtag</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -835,13 +835,13 @@ bar
         let expected = r##"<p>## foo</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -856,13 +856,13 @@ bar
         let expected = r##"<h1>foo <em>bar</em> *baz*</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -877,13 +877,13 @@ bar
         let expected = r##"<h1>foo</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -902,13 +902,13 @@ bar
 <h1>foo</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -924,13 +924,13 @@ bar
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -947,13 +947,13 @@ bar
 # bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -970,13 +970,13 @@ bar
 <h3>bar</h3>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -993,13 +993,13 @@ bar
 <h5>foo</h5>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1014,13 +1014,13 @@ bar
         let expected = r##"<h3>foo</h3>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1035,13 +1035,13 @@ bar
         let expected = r##"<h3>foo ### b</h3>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1056,13 +1056,13 @@ bar
         let expected = r##"<h1>foo#</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1081,13 +1081,13 @@ bar
 <h1>foo #</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1106,13 +1106,13 @@ bar
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1131,13 +1131,13 @@ Bar foo
 <p>Bar foo</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1156,13 +1156,13 @@ Bar foo
 <h3></h3>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1182,13 +1182,13 @@ Foo *bar*
 <h2>Foo <em>bar</em></h2>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1206,13 +1206,13 @@ baz*
 baz</em></h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1232,13 +1232,13 @@ Foo
 <h1>Foo</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1262,13 +1262,13 @@ Foo
 <h1>Foo</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1292,13 +1292,13 @@ Foo
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1314,13 +1314,13 @@ Foo
         let expected = r##"<h2>Foo</h2>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1337,13 +1337,13 @@ Foo
 ---</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1365,13 +1365,13 @@ Foo
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1387,13 +1387,13 @@ Foo
         let expected = r##"<h2>Foo</h2>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1409,13 +1409,13 @@ Foo
         let expected = r##"<h2>Foo\</h2>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1439,13 +1439,13 @@ of dashes"/>
 <p>of dashes&quot;/&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1464,13 +1464,13 @@ of dashes"/>
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1491,13 +1491,13 @@ bar
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1516,13 +1516,13 @@ bar
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1540,13 +1540,13 @@ Bar
 Bar</h2>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1569,13 +1569,13 @@ Baz
 <p>Baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1591,13 +1591,13 @@ Baz
         let expected = r##"<p>====</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1614,13 +1614,13 @@ Baz
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1639,13 +1639,13 @@ Baz
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1663,13 +1663,13 @@ Baz
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1688,13 +1688,13 @@ Baz
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1710,13 +1710,13 @@ Baz
         let expected = r##"<h2>&gt; foo</h2>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1737,13 +1737,13 @@ baz
 <p>baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1766,13 +1766,13 @@ bar</p>
 <p>baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1793,13 +1793,13 @@ bar</p>
 <p>baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1820,13 +1820,13 @@ bar
 baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1844,13 +1844,13 @@ baz</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1872,13 +1872,13 @@ baz</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1902,13 +1902,13 @@ baz</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1930,13 +1930,13 @@ baz</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1964,13 +1964,13 @@ chunk3
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -1990,13 +1990,13 @@ chunk3
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2014,13 +2014,13 @@ chunk3
 bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2038,13 +2038,13 @@ bar
 <p>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2070,13 +2070,13 @@ Heading
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2094,13 +2094,13 @@ bar
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2120,13 +2120,13 @@ bar
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2142,13 +2142,13 @@ bar
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2168,13 +2168,13 @@ bar
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2194,13 +2194,13 @@ bar
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2217,13 +2217,13 @@ foo
         let expected = r##"<p><code>foo</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2243,13 +2243,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2269,13 +2269,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2295,13 +2295,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2321,13 +2321,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2342,13 +2342,13 @@ aaa
         let expected = r##"<pre><code></code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2369,13 +2369,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2397,13 +2397,13 @@ bbb
 <p>bbb</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2423,13 +2423,13 @@ bbb
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2445,13 +2445,13 @@ bbb
         let expected = r##"<pre><code></code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2471,13 +2471,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2499,13 +2499,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2527,13 +2527,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2553,13 +2553,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2577,13 +2577,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2601,13 +2601,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2626,13 +2626,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2649,13 +2649,13 @@ aaa
 aaa</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2674,13 +2674,13 @@ aaa
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2702,13 +2702,13 @@ baz
 <p>baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2731,13 +2731,13 @@ bar
 <h1>baz</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2759,13 +2759,13 @@ end
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2787,13 +2787,13 @@ end
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2809,13 +2809,13 @@ end
         let expected = r##"<pre><code class="language-;"></code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2832,13 +2832,13 @@ foo
 foo</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2856,13 +2856,13 @@ foo</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2888,13 +2888,13 @@ _world_.
 </td></tr></table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2924,13 +2924,13 @@ okay.
 <p>okay.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2949,13 +2949,13 @@ okay.
          <foo><a>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2972,13 +2972,13 @@ okay.
 *foo*
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -2999,13 +2999,13 @@ okay.
 </DIV>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3024,13 +3024,13 @@ okay.
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3049,13 +3049,13 @@ okay.
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3075,13 +3075,13 @@ okay.
 <p><em>bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3098,13 +3098,13 @@ okay.
 *hi*
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3121,13 +3121,13 @@ foo
 foo
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3144,13 +3144,13 @@ foo
 *foo*
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3165,13 +3165,13 @@ foo
         let expected = r##"<div><a href="bar">*foo*</a></div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3190,13 +3190,13 @@ foo
 </td></tr></table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3217,13 +3217,13 @@ int x = 33;
 ```
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3242,13 +3242,13 @@ int x = 33;
 </a>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3267,13 +3267,13 @@ int x = 33;
 </Warning>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3292,13 +3292,13 @@ int x = 33;
 </i>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3315,13 +3315,13 @@ int x = 33;
 *bar*
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3340,13 +3340,13 @@ int x = 33;
 </del>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3367,13 +3367,13 @@ int x = 33;
 </del>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3388,13 +3388,13 @@ int x = 33;
         let expected = r##"<p><del><em>foo</em></del></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3421,13 +3421,13 @@ main = print $ parseTags tags
 <p>okay</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3452,13 +3452,13 @@ document.getElementById("demo").innerHTML = "Hello JavaScript!";
 <p>okay</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3485,13 +3485,13 @@ p {color:blue;}
 <p>okay</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3512,13 +3512,13 @@ foo
 foo
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3540,13 +3540,13 @@ foo
 <p>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3567,13 +3567,13 @@ foo
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3590,13 +3590,13 @@ foo
 <p><em>foo</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3613,13 +3613,13 @@ foo
 <p><em>baz</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3638,13 +3638,13 @@ foo
 </script>1. *bar*
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3667,13 +3667,13 @@ bar
 <p>okay</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3698,13 +3698,13 @@ okay
 <p>okay</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3719,13 +3719,13 @@ okay
         let expected = r##"<!DOCTYPE html>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3764,13 +3764,13 @@ function matchwo(a,b)
 <p>okay</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3789,13 +3789,13 @@ function matchwo(a,b)
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3814,13 +3814,13 @@ function matchwo(a,b)
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3841,13 +3841,13 @@ bar
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3868,13 +3868,13 @@ bar
 *foo*
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3893,13 +3893,13 @@ baz
 baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3920,13 +3920,13 @@ baz</p>
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3945,13 +3945,13 @@ baz</p>
 </div>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -3982,13 +3982,13 @@ Hi
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4020,13 +4020,13 @@ Hi
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4043,13 +4043,13 @@ Hi
         let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4068,13 +4068,13 @@ Hi
         let expected = r##"<p><a href="/url" title="the title">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4091,13 +4091,13 @@ Hi
         let expected = r##"<p><a href="my_(url)" title="title (with parens)">Foo*bar]</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4116,13 +4116,13 @@ Hi
         let expected = r##"<p><a href="my%20url" title="title">Foo bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4147,13 +4147,13 @@ line2
 ">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4174,13 +4174,13 @@ with blank line'
 <p>[foo]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4198,13 +4198,13 @@ with blank line'
         let expected = r##"<p><a href="/url">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4222,13 +4222,13 @@ with blank line'
 <p>[foo]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4245,13 +4245,13 @@ with blank line'
         let expected = r##"<p><a href="/url%5Cbar*baz" title="foo&quot;bar\baz">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4268,13 +4268,13 @@ with blank line'
         let expected = r##"<p><a href="url">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4292,13 +4292,13 @@ with blank line'
         let expected = r##"<p><a href="first">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4315,13 +4315,13 @@ with blank line'
         let expected = r##"<p><a href="/url">Foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4338,13 +4338,13 @@ with blank line'
         let expected = r##"<p><a href="/%CF%86%CE%BF%CF%85">αγω</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4358,13 +4358,13 @@ with blank line'
 "##;
         let expected = r##""##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4382,13 +4382,13 @@ bar
         let expected = r##"<p>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4403,13 +4403,13 @@ bar
         let expected = r##"<p>[foo]: /url &quot;title&quot; ok</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4425,13 +4425,13 @@ bar
         let expected = r##"<p>&quot;title&quot; ok</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4450,13 +4450,13 @@ bar
 <p>[foo]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4477,13 +4477,13 @@ bar
 <p>[foo]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4503,13 +4503,13 @@ bar
 <p>[bar]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4529,13 +4529,13 @@ bar
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4559,13 +4559,13 @@ bar
 <a href="/baz-url">baz</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4584,13 +4584,13 @@ bar
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4608,13 +4608,13 @@ bbb
 <p>bbb</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4636,13 +4636,13 @@ bbb</p>
 ddd</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4661,13 +4661,13 @@ bbb
 <p>bbb</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4684,13 +4684,13 @@ bbb
 bbb</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4709,13 +4709,13 @@ bbb
 ccc</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4732,13 +4732,13 @@ bbb
 bbb</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4756,13 +4756,13 @@ bbb
 <p>bbb</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4779,13 +4779,13 @@ bbb
 bbb</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4808,13 +4808,13 @@ aaa
 <h1>aaa</h1>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4835,13 +4835,13 @@ baz</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4862,13 +4862,13 @@ baz</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4889,13 +4889,13 @@ baz</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4915,13 +4915,13 @@ baz</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4942,13 +4942,13 @@ baz</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4969,13 +4969,13 @@ foo</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -4994,13 +4994,13 @@ foo</p>
 <hr />
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5023,13 +5023,13 @@ foo</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5050,13 +5050,13 @@ foo</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5077,13 +5077,13 @@ foo
 <pre><code></code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5102,13 +5102,13 @@ foo
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5124,13 +5124,13 @@ foo
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5148,13 +5148,13 @@ foo
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5173,13 +5173,13 @@ foo
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5201,13 +5201,13 @@ foo
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5226,13 +5226,13 @@ bar</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5252,13 +5252,13 @@ bar</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5277,13 +5277,13 @@ bar</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5306,13 +5306,13 @@ bar</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5331,13 +5331,13 @@ baz</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5357,13 +5357,13 @@ baz
 <p>baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5383,13 +5383,13 @@ baz
 <p>baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5412,13 +5412,13 @@ bar</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5443,13 +5443,13 @@ baz</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5472,13 +5472,13 @@ baz</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5504,13 +5504,13 @@ with two lines.</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5540,13 +5540,13 @@ with two lines.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5566,13 +5566,13 @@ with two lines.</p>
 <p>two</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5594,13 +5594,13 @@ with two lines.</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5621,13 +5621,13 @@ with two lines.</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5649,13 +5649,13 @@ with two lines.</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5681,13 +5681,13 @@ with two lines.</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5711,13 +5711,13 @@ with two lines.</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5735,13 +5735,13 @@ with two lines.</p>
 <p>2.two</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5764,13 +5764,13 @@ with two lines.</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5803,13 +5803,13 @@ with two lines.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5838,13 +5838,13 @@ baz
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5861,13 +5861,13 @@ baz
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5882,13 +5882,13 @@ baz
         let expected = r##"<p>1234567890. not ok</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5905,13 +5905,13 @@ baz
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5928,13 +5928,13 @@ baz
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5949,13 +5949,13 @@ baz
         let expected = r##"<p>-1. not ok</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -5978,13 +5978,13 @@ baz
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6007,13 +6007,13 @@ baz
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6036,13 +6036,13 @@ paragraph
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6069,13 +6069,13 @@ paragraph
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6102,13 +6102,13 @@ paragraph
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6126,13 +6126,13 @@ bar
 <p>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6152,13 +6152,13 @@ bar
 <p>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6180,13 +6180,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6218,13 +6218,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6242,13 +6242,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6268,13 +6268,13 @@ bar
 <p>foo</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6295,13 +6295,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6322,13 +6322,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6349,13 +6349,13 @@ bar
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6372,13 +6372,13 @@ bar
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6400,13 +6400,13 @@ foo
 1.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6436,13 +6436,13 @@ with two lines.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6472,13 +6472,13 @@ with two lines.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6508,13 +6508,13 @@ with two lines.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6540,13 +6540,13 @@ with two lines.</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6576,13 +6576,13 @@ with two lines.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6601,13 +6601,13 @@ with two lines.</li>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6632,13 +6632,13 @@ continued here.</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6663,13 +6663,13 @@ continued here.</p>
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6701,13 +6701,13 @@ continued here.</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6730,13 +6730,13 @@ continued here.</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6758,13 +6758,13 @@ continued here.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6785,13 +6785,13 @@ continued here.</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6812,13 +6812,13 @@ continued here.</p>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6843,13 +6843,13 @@ continued here.</p>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6874,13 +6874,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6903,13 +6903,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6932,13 +6932,13 @@ baz</li>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6959,13 +6959,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -6982,13 +6982,13 @@ baz</li>
 14.  The number of doors is 6.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7007,13 +7007,13 @@ baz</li>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7043,13 +7043,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7082,13 +7082,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7117,13 +7117,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7157,13 +7157,13 @@ baz</li>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7196,13 +7196,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7231,13 +7231,13 @@ baz</li>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7265,13 +7265,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7297,13 +7297,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7333,13 +7333,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7368,13 +7368,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7404,13 +7404,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7439,13 +7439,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7470,13 +7470,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7505,13 +7505,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7528,13 +7528,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7556,13 +7556,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7587,13 +7587,13 @@ baz</li>
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7619,13 +7619,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7661,13 +7661,13 @@ baz</li>
 </ul>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7682,13 +7682,13 @@ baz</li>
         let expected = r##"<p><code>hi</code>lo`</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7703,13 +7703,13 @@ baz</li>
         let expected = r##"<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7724,13 +7724,13 @@ baz</li>
         let expected = r##"<p>\	\A\a\ \3\φ\«</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7759,13 +7759,13 @@ baz</li>
 [foo]: /url &quot;not a reference&quot;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7780,13 +7780,13 @@ baz</li>
         let expected = r##"<p>\<em>emphasis</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7803,13 +7803,13 @@ bar
 bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7824,13 +7824,13 @@ bar</p>
         let expected = r##"<p><code>\[\`</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7846,13 +7846,13 @@ bar</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7870,13 +7870,13 @@ bar</p>
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7891,13 +7891,13 @@ bar</p>
         let expected = r##"<p><a href="http://example.com?find=%5C*">http://example.com?find=\*</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7912,13 +7912,13 @@ bar</p>
         let expected = r##"<a href="/bar\/)">
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7933,13 +7933,13 @@ bar</p>
         let expected = r##"<p><a href="/bar*" title="ti*tle">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7956,13 +7956,13 @@ bar</p>
         let expected = r##"<p><a href="/bar*" title="ti*tle">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -7980,13 +7980,13 @@ foo
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8005,13 +8005,13 @@ foo
 ∲ ≧̸</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8026,13 +8026,13 @@ foo
         let expected = r##"<p># Ӓ Ϡ � �</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8047,13 +8047,13 @@ foo
         let expected = r##"<p>&quot; ആ ಫ</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8070,13 +8070,13 @@ foo
 &amp;ThisIsNotDefined; &amp;hi?;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8091,13 +8091,13 @@ foo
         let expected = r##"<p>&amp;copy</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8112,13 +8112,13 @@ foo
         let expected = r##"<p>&amp;MadeUpEntity;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8133,13 +8133,13 @@ foo
         let expected = r##"<a href="&ouml;&ouml;.html">
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8154,13 +8154,13 @@ foo
         let expected = r##"<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8177,13 +8177,13 @@ foo
         let expected = r##"<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8201,13 +8201,13 @@ foo
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8222,13 +8222,13 @@ foo
         let expected = r##"<p><code>f&amp;ouml;&amp;ouml;</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8244,13 +8244,13 @@ foo
 </code></pre>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8265,13 +8265,13 @@ foo
         let expected = r##"<p><code>foo</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8286,13 +8286,13 @@ foo
         let expected = r##"<p><code>foo ` bar</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8307,13 +8307,13 @@ foo
         let expected = r##"<p><code>``</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8330,13 +8330,13 @@ foo
         let expected = r##"<p><code>foo</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8352,13 +8352,13 @@ foo
         let expected = r##"<p><code>foo bar baz</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8373,13 +8373,13 @@ foo
         let expected = r##"<p><code>a  b</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8394,13 +8394,13 @@ foo
         let expected = r##"<p><code>foo `` bar</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8415,13 +8415,13 @@ foo
         let expected = r##"<p><code>foo\</code>bar`</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8436,13 +8436,13 @@ foo
         let expected = r##"<p>*foo<code>*</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8457,13 +8457,13 @@ foo
         let expected = r##"<p>[not a <code>link](/foo</code>)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8478,13 +8478,13 @@ foo
         let expected = r##"<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8499,13 +8499,13 @@ foo
         let expected = r##"<p><a href="`">`</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8520,13 +8520,13 @@ foo
         let expected = r##"<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8541,13 +8541,13 @@ foo
         let expected = r##"<p><a href="http://foo.bar.%60baz">http://foo.bar.`baz</a>`</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8562,13 +8562,13 @@ foo
         let expected = r##"<p>```foo``</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8583,13 +8583,13 @@ foo
         let expected = r##"<p>`foo</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8604,13 +8604,13 @@ foo
         let expected = r##"<p>`foo<code>bar</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8625,13 +8625,13 @@ foo
         let expected = r##"<p><em>foo bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8646,13 +8646,13 @@ foo
         let expected = r##"<p>a * foo bar*</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8667,13 +8667,13 @@ foo
         let expected = r##"<p>a*&quot;foo&quot;*</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8688,13 +8688,13 @@ foo
         let expected = r##"<p>* a *</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8709,13 +8709,13 @@ foo
         let expected = r##"<p>foo<em>bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8730,13 +8730,13 @@ foo
         let expected = r##"<p>5<em>6</em>78</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8751,13 +8751,13 @@ foo
         let expected = r##"<p><em>foo bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8772,13 +8772,13 @@ foo
         let expected = r##"<p>_ foo bar_</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8793,13 +8793,13 @@ foo
         let expected = r##"<p>a_&quot;foo&quot;_</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8814,13 +8814,13 @@ foo
         let expected = r##"<p>foo_bar_</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8835,13 +8835,13 @@ foo
         let expected = r##"<p>5_6_78</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8856,13 +8856,13 @@ foo
         let expected = r##"<p>пристаням_стремятся_</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8877,13 +8877,13 @@ foo
         let expected = r##"<p>aa_&quot;bb&quot;_cc</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8898,13 +8898,13 @@ foo
         let expected = r##"<p>foo-<em>(bar)</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8919,13 +8919,13 @@ foo
         let expected = r##"<p>_foo*</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8940,13 +8940,13 @@ foo
         let expected = r##"<p>*foo bar *</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8963,13 +8963,13 @@ foo
 *</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -8984,13 +8984,13 @@ foo
         let expected = r##"<p>*(*foo)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9005,13 +9005,13 @@ foo
         let expected = r##"<p><em>(<em>foo</em>)</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9026,13 +9026,13 @@ foo
         let expected = r##"<p><em>foo</em>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9047,13 +9047,13 @@ foo
         let expected = r##"<p>_foo bar _</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9068,13 +9068,13 @@ foo
         let expected = r##"<p>_(_foo)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9089,13 +9089,13 @@ foo
         let expected = r##"<p><em>(<em>foo</em>)</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9110,13 +9110,13 @@ foo
         let expected = r##"<p>_foo_bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9131,13 +9131,13 @@ foo
         let expected = r##"<p>_пристаням_стремятся</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9152,13 +9152,13 @@ foo
         let expected = r##"<p><em>foo_bar_baz</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9173,13 +9173,13 @@ foo
         let expected = r##"<p><em>(bar)</em>.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9194,13 +9194,13 @@ foo
         let expected = r##"<p><strong>foo bar</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9215,13 +9215,13 @@ foo
         let expected = r##"<p>** foo bar**</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9236,13 +9236,13 @@ foo
         let expected = r##"<p>a**&quot;foo&quot;**</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9257,13 +9257,13 @@ foo
         let expected = r##"<p>foo<strong>bar</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9278,13 +9278,13 @@ foo
         let expected = r##"<p><strong>foo bar</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9299,13 +9299,13 @@ foo
         let expected = r##"<p>__ foo bar__</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9322,13 +9322,13 @@ foo bar__
 foo bar__</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9343,13 +9343,13 @@ foo bar__</p>
         let expected = r##"<p>a__&quot;foo&quot;__</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9364,13 +9364,13 @@ foo bar__</p>
         let expected = r##"<p>foo__bar__</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9385,13 +9385,13 @@ foo bar__</p>
         let expected = r##"<p>5__6__78</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9406,13 +9406,13 @@ foo bar__</p>
         let expected = r##"<p>пристаням__стремятся__</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9427,13 +9427,13 @@ foo bar__</p>
         let expected = r##"<p><strong>foo, <strong>bar</strong>, baz</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9448,13 +9448,13 @@ foo bar__</p>
         let expected = r##"<p>foo-<strong>(bar)</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9469,13 +9469,13 @@ foo bar__</p>
         let expected = r##"<p>**foo bar **</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9490,13 +9490,13 @@ foo bar__</p>
         let expected = r##"<p>**(**foo)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9511,13 +9511,13 @@ foo bar__</p>
         let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9534,13 +9534,13 @@ foo bar__</p>
 <em>Asclepias physocarpa</em>)</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9555,13 +9555,13 @@ foo bar__</p>
         let expected = r##"<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9576,13 +9576,13 @@ foo bar__</p>
         let expected = r##"<p><strong>foo</strong>bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9597,13 +9597,13 @@ foo bar__</p>
         let expected = r##"<p>__foo bar __</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9618,13 +9618,13 @@ foo bar__</p>
         let expected = r##"<p>__(__foo)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9639,13 +9639,13 @@ foo bar__</p>
         let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9660,13 +9660,13 @@ foo bar__</p>
         let expected = r##"<p>__foo__bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9681,13 +9681,13 @@ foo bar__</p>
         let expected = r##"<p>__пристаням__стремятся</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9702,13 +9702,13 @@ foo bar__</p>
         let expected = r##"<p><strong>foo__bar__baz</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9723,13 +9723,13 @@ foo bar__</p>
         let expected = r##"<p><strong>(bar)</strong>.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9744,13 +9744,13 @@ foo bar__</p>
         let expected = r##"<p><em>foo <a href="/url">bar</a></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9767,13 +9767,13 @@ bar*
 bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9788,13 +9788,13 @@ bar</em></p>
         let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9809,13 +9809,13 @@ bar</em></p>
         let expected = r##"<p><em>foo <em>bar</em> baz</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9830,13 +9830,13 @@ bar</em></p>
         let expected = r##"<p><em><em>foo</em> bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9851,13 +9851,13 @@ bar</em></p>
         let expected = r##"<p><em>foo <em>bar</em></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9872,13 +9872,13 @@ bar</em></p>
         let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9893,13 +9893,13 @@ bar</em></p>
         let expected = r##"<p><em>foo<strong>bar</strong>baz</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9914,13 +9914,13 @@ bar</em></p>
         let expected = r##"<p><em><strong>foo</strong> bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9935,13 +9935,13 @@ bar</em></p>
         let expected = r##"<p><em>foo <strong>bar</strong></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9956,13 +9956,13 @@ bar</em></p>
         let expected = r##"<p><em>foo<strong>bar</strong></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9977,13 +9977,13 @@ bar</em></p>
         let expected = r##"<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -9998,13 +9998,13 @@ bar</em></p>
         let expected = r##"<p><em>foo <a href="/url"><em>bar</em></a></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10019,13 +10019,13 @@ bar</em></p>
         let expected = r##"<p>** is not an empty emphasis</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10040,13 +10040,13 @@ bar</em></p>
         let expected = r##"<p>**** is not an empty strong emphasis</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10061,13 +10061,13 @@ bar</em></p>
         let expected = r##"<p><strong>foo <a href="/url">bar</a></strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10084,13 +10084,13 @@ bar**
 bar</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10105,13 +10105,13 @@ bar</strong></p>
         let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10126,13 +10126,13 @@ bar</strong></p>
         let expected = r##"<p><strong>foo <strong>bar</strong> baz</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10147,13 +10147,13 @@ bar</strong></p>
         let expected = r##"<p><strong><strong>foo</strong> bar</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10168,13 +10168,13 @@ bar</strong></p>
         let expected = r##"<p><strong>foo <strong>bar</strong></strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10189,13 +10189,13 @@ bar</strong></p>
         let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10210,13 +10210,13 @@ bar</strong></p>
         let expected = r##"<p><strong>foo<em>bar</em>baz</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10231,13 +10231,13 @@ bar</strong></p>
         let expected = r##"<p><strong><em>foo</em> bar</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10252,13 +10252,13 @@ bar</strong></p>
         let expected = r##"<p><strong>foo <em>bar</em></strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10275,13 +10275,13 @@ bim* bop**
 bim</em> bop</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10296,13 +10296,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong>foo <a href="/url"><em>bar</em></a></strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10317,13 +10317,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>__ is not an empty emphasis</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10338,13 +10338,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>____ is not an empty strong emphasis</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10359,13 +10359,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo ***</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10380,13 +10380,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <em>*</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10401,13 +10401,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <em>_</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10422,13 +10422,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo *****</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10443,13 +10443,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <strong>*</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10464,13 +10464,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <strong>_</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10485,13 +10485,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>*<em>foo</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10506,13 +10506,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>foo</em>*</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10527,13 +10527,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>*<strong>foo</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10548,13 +10548,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>***<em>foo</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10569,13 +10569,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong>foo</strong>*</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10590,13 +10590,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>foo</em>***</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10611,13 +10611,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo ___</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10632,13 +10632,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <em>_</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10653,13 +10653,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <em>*</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10674,13 +10674,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo _____</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10695,13 +10695,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <strong>_</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10716,13 +10716,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>foo <strong>*</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10737,13 +10737,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>_<em>foo</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10758,13 +10758,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>foo</em>_</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10779,13 +10779,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>_<strong>foo</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10800,13 +10800,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>___<em>foo</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10821,13 +10821,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong>foo</strong>_</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10842,13 +10842,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>foo</em>___</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10863,13 +10863,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong>foo</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10884,13 +10884,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em><em>foo</em></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10905,13 +10905,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong>foo</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10926,13 +10926,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em><em>foo</em></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10947,13 +10947,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong><strong>foo</strong></strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10968,13 +10968,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong><strong>foo</strong></strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -10989,13 +10989,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><strong><strong><strong>foo</strong></strong></strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11010,13 +11010,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em><strong>foo</strong></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11031,13 +11031,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em><strong><strong>foo</strong></strong></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11052,13 +11052,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>foo _bar</em> baz_</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11073,13 +11073,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>foo <strong>bar *baz bim</strong> bam</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11094,13 +11094,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>**foo <strong>bar baz</strong></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11115,13 +11115,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>*foo <em>bar baz</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11136,13 +11136,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>*<a href="/url">bar*</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11157,13 +11157,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>_foo <a href="/url">bar_</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11178,13 +11178,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>*<img src="foo" title="*"/></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11199,13 +11199,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>**<a href="**"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11220,13 +11220,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>__<a href="__"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11241,13 +11241,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>a <code>*</code></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11262,13 +11262,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><em>a <code>_</code></em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11283,13 +11283,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11304,13 +11304,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11325,13 +11325,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><a href="/uri" title="title">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11346,13 +11346,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><a href="/uri">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11367,13 +11367,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><a href="">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11388,13 +11388,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p><a href="">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11409,13 +11409,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>[link](/my uri)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11430,13 +11430,13 @@ bim</em> bop</strong></p>
         let expected = r##"<p>[link](&lt;/my uri&gt;)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11453,13 +11453,13 @@ bar)
 bar)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11476,13 +11476,13 @@ bar>)
 bar>)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11497,13 +11497,13 @@ bar>)</p>
         let expected = r##"<p><a href="(foo)">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11518,13 +11518,13 @@ bar>)</p>
         let expected = r##"<p><a href="foo(and(bar))">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11539,13 +11539,13 @@ bar>)</p>
         let expected = r##"<p><a href="foo(and(bar)">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11560,13 +11560,13 @@ bar>)</p>
         let expected = r##"<p><a href="foo(and(bar)">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11581,13 +11581,13 @@ bar>)</p>
         let expected = r##"<p><a href="foo):">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11608,13 +11608,13 @@ bar>)</p>
 <p><a href="http://example.com?foo=3#frag">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11629,13 +11629,13 @@ bar>)</p>
         let expected = r##"<p><a href="foo%5Cbar">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11650,13 +11650,13 @@ bar>)</p>
         let expected = r##"<p><a href="foo%20b%C3%A4">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11671,13 +11671,13 @@ bar>)</p>
         let expected = r##"<p><a href="%22title%22">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11696,13 +11696,13 @@ bar>)</p>
 <a href="/url" title="title">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11717,13 +11717,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title &quot;&quot;">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11738,13 +11738,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url%C2%A0%22title%22">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11759,13 +11759,13 @@ bar>)</p>
         let expected = r##"<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11780,13 +11780,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title &quot;and&quot; title">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11802,13 +11802,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri" title="title">link</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11823,13 +11823,13 @@ bar>)</p>
         let expected = r##"<p>[link] (/uri)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11844,13 +11844,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">link [foo [bar]]</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11865,13 +11865,13 @@ bar>)</p>
         let expected = r##"<p>[link] bar](/uri)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11886,13 +11886,13 @@ bar>)</p>
         let expected = r##"<p>[link <a href="/uri">bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11907,13 +11907,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">link [bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11928,13 +11928,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11949,13 +11949,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11970,13 +11970,13 @@ bar>)</p>
         let expected = r##"<p>[foo <a href="/uri">bar</a>](/uri)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -11991,13 +11991,13 @@ bar>)</p>
         let expected = r##"<p>[foo <em>[bar <a href="/uri">baz</a>](/uri)</em>](/uri)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12012,13 +12012,13 @@ bar>)</p>
         let expected = r##"<p><img src="uri3" alt="[foo](uri2)" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12033,13 +12033,13 @@ bar>)</p>
         let expected = r##"<p>*<a href="/uri">foo*</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12054,13 +12054,13 @@ bar>)</p>
         let expected = r##"<p><a href="baz*">foo *bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12075,13 +12075,13 @@ bar>)</p>
         let expected = r##"<p><em>foo [bar</em> baz]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12096,13 +12096,13 @@ bar>)</p>
         let expected = r##"<p>[foo <bar attr="](baz)"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12117,13 +12117,13 @@ bar>)</p>
         let expected = r##"<p>[foo<code>](/uri)</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12138,13 +12138,13 @@ bar>)</p>
         let expected = r##"<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12161,13 +12161,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12184,13 +12184,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">link [foo [bar]]</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12207,13 +12207,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">link [bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12230,13 +12230,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12253,13 +12253,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12276,13 +12276,13 @@ bar>)</p>
         let expected = r##"<p>[foo <a href="/uri">bar</a>]<a href="/uri">ref</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12299,13 +12299,13 @@ bar>)</p>
         let expected = r##"<p>[foo <em>bar <a href="/uri">baz</a></em>]<a href="/uri">ref</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12322,13 +12322,13 @@ bar>)</p>
         let expected = r##"<p>*<a href="/uri">foo*</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12345,13 +12345,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">foo *bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12368,13 +12368,13 @@ bar>)</p>
         let expected = r##"<p>[foo <bar attr="][ref]"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12391,13 +12391,13 @@ bar>)</p>
         let expected = r##"<p>[foo<code>][ref]</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12414,13 +12414,13 @@ bar>)</p>
         let expected = r##"<p>[foo<a href="http://example.com/?search=%5D%5Bref%5D">http://example.com/?search=][ref]</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12437,13 +12437,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12460,13 +12460,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url">Толпой</a> is a Russian word.</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12484,13 +12484,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url">Baz</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12507,13 +12507,13 @@ bar>)</p>
         let expected = r##"<p>[foo] <a href="/url" title="title">bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12532,13 +12532,13 @@ bar>)</p>
 <a href="/url" title="title">bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12557,13 +12557,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url1">bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12580,13 +12580,13 @@ bar>)</p>
         let expected = r##"<p>[bar][foo!]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12604,13 +12604,13 @@ bar>)</p>
 <p>[ref[]: /uri</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12628,13 +12628,13 @@ bar>)</p>
 <p>[ref[bar]]: /uri</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12652,13 +12652,13 @@ bar>)</p>
 <p>[[[foo]]]: /url</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12675,13 +12675,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12698,13 +12698,13 @@ bar>)</p>
         let expected = r##"<p><a href="/uri">bar\</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12722,13 +12722,13 @@ bar>)</p>
 <p>[]: /uri</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12750,13 +12750,13 @@ bar>)</p>
 ]: /uri</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12773,13 +12773,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12796,13 +12796,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title"><em>foo</em> bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12819,13 +12819,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title">Foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12844,13 +12844,13 @@ bar>)</p>
 []</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12867,13 +12867,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12890,13 +12890,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title"><em>foo</em> bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12913,13 +12913,13 @@ bar>)</p>
         let expected = r##"<p>[<a href="/url" title="title"><em>foo</em> bar</a>]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12936,13 +12936,13 @@ bar>)</p>
         let expected = r##"<p>[[bar <a href="/url">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12959,13 +12959,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url" title="title">Foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -12982,13 +12982,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url">foo</a> bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13005,13 +13005,13 @@ bar>)</p>
         let expected = r##"<p>[foo]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13028,13 +13028,13 @@ bar>)</p>
         let expected = r##"<p>*<a href="/url">foo*</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13052,13 +13052,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url2">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13075,13 +13075,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url1">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13098,13 +13098,13 @@ bar>)</p>
         let expected = r##"<p><a href="">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13121,13 +13121,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url1">foo</a>(not a link)</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13144,13 +13144,13 @@ bar>)</p>
         let expected = r##"<p>[foo]<a href="/url">bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13168,13 +13168,13 @@ bar>)</p>
         let expected = r##"<p><a href="/url2">foo</a><a href="/url1">baz</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13192,13 +13192,13 @@ bar>)</p>
         let expected = r##"<p>[foo]<a href="/url1">bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13213,13 +13213,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13236,13 +13236,13 @@ bar>)</p>
         let expected = r##"<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13257,13 +13257,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13278,13 +13278,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13301,13 +13301,13 @@ bar>)</p>
         let expected = r##"<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13324,13 +13324,13 @@ bar>)</p>
         let expected = r##"<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13345,13 +13345,13 @@ bar>)</p>
         let expected = r##"<p><img src="train.jpg" alt="foo" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13366,13 +13366,13 @@ bar>)</p>
         let expected = r##"<p>My <img src="/path/to/train.jpg" alt="foo bar" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13387,13 +13387,13 @@ bar>)</p>
         let expected = r##"<p><img src="url" alt="foo" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13408,13 +13408,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13431,13 +13431,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="foo" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13454,13 +13454,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="foo" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13477,13 +13477,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13500,13 +13500,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="foo bar" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13523,13 +13523,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="Foo" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13548,13 +13548,13 @@ bar>)</p>
 []</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13571,13 +13571,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13594,13 +13594,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="foo bar" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13618,13 +13618,13 @@ bar>)</p>
 <p>[[foo]]: /url &quot;title&quot;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13641,13 +13641,13 @@ bar>)</p>
         let expected = r##"<p><img src="/url" alt="Foo" title="title" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13664,13 +13664,13 @@ bar>)</p>
         let expected = r##"<p>![foo]</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13687,13 +13687,13 @@ bar>)</p>
         let expected = r##"<p>!<a href="/url" title="title">foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13708,13 +13708,13 @@ bar>)</p>
         let expected = r##"<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13729,13 +13729,13 @@ bar>)</p>
         let expected = r##"<p><a href="http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13750,13 +13750,13 @@ bar>)</p>
         let expected = r##"<p><a href="irc://foo.bar:2233/baz">irc://foo.bar:2233/baz</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13771,13 +13771,13 @@ bar>)</p>
         let expected = r##"<p><a href="MAILTO:FOO@BAR.BAZ">MAILTO:FOO@BAR.BAZ</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13792,13 +13792,13 @@ bar>)</p>
         let expected = r##"<p><a href="a+b+c:d">a+b+c:d</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13813,13 +13813,13 @@ bar>)</p>
         let expected = r##"<p><a href="made-up-scheme://foo,bar">made-up-scheme://foo,bar</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13834,13 +13834,13 @@ bar>)</p>
         let expected = r##"<p><a href="http://../">http://../</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13855,13 +13855,13 @@ bar>)</p>
         let expected = r##"<p><a href="localhost:5001/foo">localhost:5001/foo</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13876,13 +13876,13 @@ bar>)</p>
         let expected = r##"<p>&lt;http://foo.bar/baz bim&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13897,13 +13897,13 @@ bar>)</p>
         let expected = r##"<p><a href="http://example.com/%5C%5B%5C">http://example.com/\[\</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13918,13 +13918,13 @@ bar>)</p>
         let expected = r##"<p><a href="mailto:foo@bar.example.com">foo@bar.example.com</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13939,13 +13939,13 @@ bar>)</p>
         let expected = r##"<p><a href="mailto:foo+special@Bar.baz-bar0.com">foo+special@Bar.baz-bar0.com</a></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13960,13 +13960,13 @@ bar>)</p>
         let expected = r##"<p>&lt;foo+@bar.example.com&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -13981,13 +13981,13 @@ bar>)</p>
         let expected = r##"<p>&lt;&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14002,13 +14002,13 @@ bar>)</p>
         let expected = r##"<p>&lt; http://foo.bar &gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14023,13 +14023,13 @@ bar>)</p>
         let expected = r##"<p>&lt;m:abc&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14044,13 +14044,13 @@ bar>)</p>
         let expected = r##"<p>&lt;foo.bar.baz&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14065,13 +14065,13 @@ bar>)</p>
         let expected = r##"<p>http://example.com</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14086,13 +14086,13 @@ bar>)</p>
         let expected = r##"<p>foo@bar.example.com</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14107,13 +14107,13 @@ bar>)</p>
         let expected = r##"<p><a><bab><c2c></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14128,13 +14128,13 @@ bar>)</p>
         let expected = r##"<p><a/><b2/></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14151,13 +14151,13 @@ data="foo" >
 data="foo" ></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14174,13 +14174,13 @@ _boolean zoop:33=zoop:33 />
 _boolean zoop:33=zoop:33 /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14195,13 +14195,13 @@ _boolean zoop:33=zoop:33 /></p>
         let expected = r##"<p>Foo <responsive-image src="foo.jpg" /></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14216,13 +14216,13 @@ _boolean zoop:33=zoop:33 /></p>
         let expected = r##"<p>&lt;33&gt; &lt;__&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14237,13 +14237,13 @@ _boolean zoop:33=zoop:33 /></p>
         let expected = r##"<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14258,13 +14258,13 @@ _boolean zoop:33=zoop:33 /></p>
         let expected = r##"<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14281,13 +14281,13 @@ foo><bar/ >
 foo&gt;&lt;bar/ &gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14302,13 +14302,13 @@ foo&gt;&lt;bar/ &gt;</p>
         let expected = r##"<p>&lt;a href='bar'title=title&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14323,13 +14323,13 @@ foo&gt;&lt;bar/ &gt;</p>
         let expected = r##"<p></a></foo ></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14344,13 +14344,13 @@ foo&gt;&lt;bar/ &gt;</p>
         let expected = r##"<p>&lt;/a href=&quot;foo&quot;&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14367,13 +14367,13 @@ comment - with hyphen -->
 comment - with hyphen --></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14388,13 +14388,13 @@ comment - with hyphen --></p>
         let expected = r##"<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14412,13 +14412,13 @@ foo <!-- foo--->
 <p>foo &lt;!-- foo---&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14433,13 +14433,13 @@ foo <!-- foo--->
         let expected = r##"<p>foo <?php echo $a; ?></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14454,13 +14454,13 @@ foo <!-- foo--->
         let expected = r##"<p>foo <!ELEMENT br EMPTY></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14475,13 +14475,13 @@ foo <!-- foo--->
         let expected = r##"<p>foo <![CDATA[>&<]]></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14496,13 +14496,13 @@ foo <!-- foo--->
         let expected = r##"<p>foo <a href="&ouml;"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14517,13 +14517,13 @@ foo <!-- foo--->
         let expected = r##"<p>foo <a href="\*"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14538,13 +14538,13 @@ foo <!-- foo--->
         let expected = r##"<p>&lt;a href=&quot;&quot;&quot;&gt;</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14561,13 +14561,13 @@ baz
 baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14584,13 +14584,13 @@ baz
 baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14607,13 +14607,13 @@ baz
 baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14630,13 +14630,13 @@ baz</p>
 bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14653,13 +14653,13 @@ bar</p>
 bar</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14676,13 +14676,13 @@ bar*
 bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14699,13 +14699,13 @@ bar*
 bar</em></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14721,13 +14721,13 @@ span`
         let expected = r##"<p><code>code span</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14743,13 +14743,13 @@ span`
         let expected = r##"<p><code>code\ span</code></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14766,13 +14766,13 @@ bar">
 bar"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14789,13 +14789,13 @@ bar">
 bar"></p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14810,13 +14810,13 @@ bar"></p>
         let expected = r##"<p>foo\</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14831,13 +14831,13 @@ bar"></p>
         let expected = r##"<p>foo</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14852,13 +14852,13 @@ bar"></p>
         let expected = r##"<h3>foo\</h3>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14873,13 +14873,13 @@ bar"></p>
         let expected = r##"<h3>foo</h3>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14896,13 +14896,13 @@ baz
 baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14919,13 +14919,13 @@ baz</p>
 baz</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14940,13 +14940,13 @@ baz</p>
         let expected = r##"<p>hello $.;'there</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14961,13 +14961,13 @@ baz</p>
         let expected = r##"<p>Foo χρῆν</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -14982,13 +14982,13 @@ baz</p>
         let expected = r##"<p>Multiple     spaces</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -12,13 +12,13 @@ extern crate pulldown_cmark;
         let expected = r##"<h2>Test header</h2>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -35,13 +35,13 @@ extern crate pulldown_cmark;
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -65,13 +65,13 @@ Test ending
 <p>Test ending</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -97,13 +97,13 @@ Test ending
 </blockquote>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -135,13 +135,13 @@ Test ending
 </ol>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -162,13 +162,13 @@ Test ending
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -189,13 +189,13 @@ Test ending
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -216,13 +216,13 @@ Test ending
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -243,13 +243,13 @@ Test ending
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -280,13 +280,13 @@ Test ending
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -303,13 +303,13 @@ Test ending
 |ぃ|い|</p>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -328,13 +328,13 @@ Test ending
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);
@@ -353,13 +353,13 @@ Test ending
 </table>
 "##;
 
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+        use pulldown_cmark::{Parser, html, Options};
 
         let mut s = String::new();
 
         let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
 
         let p = Parser::new_ext(&original, opts);
         html::push_html(&mut s, p);


### PR DESCRIPTION
This is breaking change because it is changing OPTIONS_* to Options::*
which is part of API.

Originally-written-by: Chet Gurevitch <chetgurevitch@protonmail.com>
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>