### PR TITLE
Implement autolinks on new_algo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "A pull parser for CommonMark"
 repository = "https://github.com/raphlinus/pulldown-cmark"
 keywords = ["markdown", "commonmark"]
 categories = ["text-processing"]
+edition = "2018"
 
 build = "build.rs"
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -24,10 +24,10 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use parse::{Event, Tag};
-use parse::Event::{Start, End, Text, Html, InlineHtml, SoftBreak, HardBreak, FootnoteReference};
-use parse::Alignment;
-use escape::{escape_html, escape_href};
+use crate::parse::{Event, Tag};
+use crate::parse::Event::{Start, End, Text, Html, InlineHtml, SoftBreak, HardBreak, FootnoteReference};
+use crate::parse::Alignment;
+use crate::escape::{escape_html, escape_href};
 
 enum TableState {
     Head,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,5 +39,5 @@ mod utils;
 mod prototype;
 mod tree;
 
-pub use prototype::Parser;
-pub use parse::{Alignment, Event, Tag, Options};
+pub use crate::prototype::Parser;
+pub use crate::parse::{Alignment, Event, Tag, Options};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,8 +20,8 @@
 
 //! Raw parser, for doing a single pass over input.
 
-use scanners::*;
-use utils;
+use crate::scanners::*;
+use crate::utils;
 use std::borrow::Cow;
 use std::borrow::Cow::{Borrowed};
 use std::collections::{HashMap, HashSet};

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -23,9 +23,9 @@
 use std::borrow::Cow;
 use std::borrow::Cow::Borrowed;
 
-use parse::{Event, Tag, Options};
-use scanners::*;
-use tree::{NIL, Node, Tree};
+use crate::parse::{Event, Tag, Options};
+use crate::scanners::*;
+use crate::tree::{NIL, Node, Tree};
 
 #[derive(Debug)]
 struct Item {

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -20,14 +20,14 @@
 
 //! Scanners for fragments of CommonMark syntax
 
-use entities;
-use utils;
+use crate::entities;
+use crate::utils;
 use std::borrow::Cow;
 use std::borrow::Cow::{Borrowed, Owned};
 use std::char;
-use parse::Alignment;
+use crate::parse::Alignment;
 
-pub use puncttable::{is_ascii_punctuation, is_punctuation};
+pub use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 
 // sorted for binary_search
 const HTML_TAGS: [&'static str; 72] = ["address", "article", "aside", "base", 


### PR DESCRIPTION
Also moves to edition 2018. Brings passing tests to 480/633.

Replaces https://github.com/raphlinus/pulldown-cmark/pull/172.