### PR TITLE
List parsing tweaks

### DIFF
--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -245,7 +245,7 @@ impl<'a> FirstPass<'a> {
                 // interrupt or not?)
                 let suffix = &self.text[ix_new..];
                 let grandparent_node = self.tree.peek_grandparent();
-                let ix = scan_listitem(suffix).0;
+                let (ix, delim, index, _) = scan_listitem(suffix);
                 if {
                     ix > 0 &&
                     (grandparent_node.is_some() &&
@@ -254,7 +254,8 @@ impl<'a> FirstPass<'a> {
                     } else {
                         false
                     }
-                    || !scan_empty_list(&suffix[ix..]))
+                    || (!scan_empty_list(&suffix[ix..]))
+                    && (delim == b'*' || delim == b'-' || index == 1))
                 } || scan_paragraph_interrupt(suffix) {
                     break;
                 }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -527,7 +527,9 @@ impl<'a> FirstPass<'a> {
         for &node_ix in &self.tree.spine {
             match self.tree.nodes[node_ix].item.body {
                 ItemBody::BlockQuote => {
+                    let save = line_start.clone();
                     if !line_start.scan_blockquote_marker() {
+                        *line_start = save;
                         break;
                     }
                 }
@@ -1113,6 +1115,9 @@ fn parse_html_line_type_6or7(tree : &mut Tree<Item>, s : &str, mut ix : usize) -
     ix
 }
 
+/// Checks whether we should break a paragraph on the given input.
+/// Note: lists are dealt with in `interrupt_paragraph_by_list`, because determing
+/// whether to break on a list requires additional context.
 fn scan_paragraph_interrupt(s: &str) -> bool {
     scan_eol(s).1 ||
     scan_hrule(s) > 0 ||

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -198,7 +198,7 @@ impl<'a> LineStart<'a> {
                         // TODO (breaking API change): should be u64, not usize.
                         if val_usize as u64 != val { return None; }                        
                         if self.scan_space(1) || self.is_at_eol() {
-                            return self.finish_list_marker(c, val_usize, self.ix - start_ix);
+                            return self.finish_list_marker(c, val_usize, indent + self.ix - start_ix);
                         }
                     }
                 }
@@ -621,6 +621,19 @@ pub fn scan_blockquote_start(data: &str) -> usize {
     } else {
         0
     }
+}
+
+/// This already assumes the list item has been scanned.
+pub fn scan_empty_list(data: &str) -> bool {
+    let mut ix = 0;
+    for _ in 0..2 {
+        if let Some(bytes) = scan_blank_line(&data[ix..]) {
+            ix += bytes;
+        } else {
+            return false;
+        }
+    }
+    true
 }
 
 // return number of bytes scanned, delimiter, start index, and indent

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -142,7 +142,7 @@ impl<'a> LineStart<'a> {
         c == b'\r' || c == b'\n'
     }
 
-    fn scan_ch(&mut self, c: u8) -> bool {
+    pub fn scan_ch(&mut self, c: u8) -> bool {
         if self.ix < self.text.len() && self.text.as_bytes()[self.ix] == c {
             self.ix += 1;
             true
@@ -219,8 +219,8 @@ impl<'a> LineStart<'a> {
             self.ix += n;
 
             if let Some(_) = scan_blank_line(&self.text[self.ix..]) {
-                // a completely blank line - let's revert
-                self.ix = ix;
+                // a completely blank line - let's revert to beginning of the line
+                self.ix = ix + 1;
             } else {
                 indent = self.scan_space_upto(3);
             }
@@ -324,9 +324,10 @@ pub fn scan_attr_value_chars(data: &str) -> usize {
 // Maybe returning Option<usize> would be more Rustic?
 pub fn scan_eol(s: &str) -> (usize, bool) {
     if s.is_empty() { return (0, true); }
-    match s.as_bytes()[0] {
+    let bytes = s.as_bytes();
+    match bytes[0] {
         b'\n' => (1, true),
-        b'\r' => (if s[1..].starts_with('\n') { 2 } else { 1 }, true),
+        b'\r' => (if bytes[1] == b'\n' { 2 } else { 1 }, true),
         _ => (0, false)
     }
 }

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -142,7 +142,7 @@ impl<'a> LineStart<'a> {
         c == b'\r' || c == b'\n'
     }
 
-    pub fn scan_ch(&mut self, c: u8) -> bool {
+    fn scan_ch(&mut self, c: u8) -> bool {
         if self.ix < self.text.len() && self.text.as_bytes()[self.ix] == c {
             self.ix += 1;
             true

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -212,12 +212,28 @@ impl<'a> LineStart<'a> {
         -> Option<(u8, usize, usize)>
     {
         let save = self.clone();
+
+        // skip the rest of the line if it's blank
+        if let Some(n) = scan_blank_line(&self.text[self.ix..]) {
+            let ix = self.ix;
+            self.ix += n;
+
+            if let Some(_) = scan_blank_line(&self.text[self.ix..]) {
+                // a completely blank line - let's revert
+                self.ix = ix;
+            } else {
+                indent = 0;
+            }
+        }
+
         let post_indent = self.scan_space_upto(4);
         if post_indent < 4 {
             indent += post_indent;
         } else {
             *self = save;
         }
+        eprintln!("found marker with indent: {}", indent);
+
         Some((c, start, indent))
     }
 

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -327,7 +327,7 @@ pub fn scan_eol(s: &str) -> (usize, bool) {
     let bytes = s.as_bytes();
     match bytes[0] {
         b'\n' => (1, true),
-        b'\r' => (if bytes[1] == b'\n' { 2 } else { 1 }, true),
+        b'\r' => (if s[1..].starts_with('\n') { 2 } else { 1 }, true),
         _ => (0, false)
     }
 }

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -222,7 +222,7 @@ impl<'a> LineStart<'a> {
                 // a completely blank line - let's revert
                 self.ix = ix;
             } else {
-                indent = 0;
+                indent = self.scan_space_upto(3);
             }
         }
 
@@ -232,8 +232,6 @@ impl<'a> LineStart<'a> {
         } else {
             *self = save;
         }
-        eprintln!("found marker with indent: {}", indent);
-
         Some((c, start, indent))
     }
 

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -170,7 +170,7 @@ impl<'a> LineStart<'a> {
     /// bullet list markers, it will be one of b'-', b'+', or b'*'.
     pub fn scan_list_marker(&mut self) -> Option<(u8, usize, usize)> {
         let save = self.clone();
-        let mut indent = self.scan_space_upto(3);
+        let indent = self.scan_space_upto(3);
         if self.ix < self.text.len() {
             let c = self.text.as_bytes()[self.ix];
             if c == b'-' || c == b'+' || c == b'*' {
@@ -192,13 +192,14 @@ impl<'a> LineStart<'a> {
                     if c >= b'0' && c <= b'9' {
                         val = val * 10 + (c - b'0') as u64;
                     } else if c == b')' || c == b'.' {
-                        self.ix = ix + 1;
-                        indent += ix + 1 - start_ix;
+                        self.ix = ix;
                         let val_usize = val as usize;
                         // This will cause some failures on 32 bit arch.
                         // TODO (breaking API change): should be u64, not usize.
-                        if val_usize as u64 != val { return None; }
-                        return self.finish_list_marker(c, val_usize, indent);
+                        if val_usize as u64 != val { return None; }                        
+                        if self.scan_space(1) || self.is_at_eol() {
+                            return self.finish_list_marker(c, val_usize, self.ix - start_ix);
+                        }
                     }
                 }
             }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -70,7 +70,7 @@ impl<T> Tree<T> {
     }
 
     /// Look at grandparent node.
-    pub fn peek_grandparent(&mut self) -> Option<usize> {
+    pub fn peek_grandparent(&self) -> Option<usize> {
         if self.spine.len() >= 2 {
             Some(self.spine[self.spine.len() - 2].clone())
         } else {

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -6248,10 +6248,12 @@ bar
     fn spec_test_243() {
         let original = r##"-
   foo
-- ```
+-
+  ```
   bar
   ```
--     baz
+-
+      baz
 "##;
         let expected = r##"<ul>
 <li>foo</li>

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -6248,12 +6248,10 @@ bar
     fn spec_test_243() {
         let original = r##"-
   foo
--
-  ```
+- ```
   bar
   ```
--
-      baz
+-     baz
 "##;
         let expected = r##"<ul>
 <li>foo</li>


### PR DESCRIPTION
This makes a number of list parsing tests pass, brining the total to 616/633. There's two remaining list tests failing:
* [this one involving an empty blockquote inside a list](https://spec.commonmark.org/0.28/#example-281) which I couldn't get tight, and
* [this one](https://spec.commonmark.org/0.28/#example-241) where it seems like we need the indentation of the previous list markers to correctly handle the final item? Or am I missing something here?

As always, all feedback greatly appreciated. Especially on those two remaining cases ;-)