### PR TITLE
Encoding fixes take two

### DIFF
--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -1003,6 +1003,10 @@ fn delim_run_can_close(s: &str, suffix: &str, run_len: usize, ix: usize) -> bool
     next_char.is_whitespace() || next_char.is_ascii_punctuation()
 }
 
+// TODO: we could have a different ItemBody for this kind of text, 
+// producing a different node which makes getting either raw or unescaped
+// text explicit. This would eliminate an allocation/ copy when parsing
+// to HTML for example.
 fn unescape_and_append<'a>(tree: &mut Tree<Item<'a>>, text: &'a str, start: usize, end: usize) {
     if end > start {
         match unescape(&text[start..end]) {

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -946,7 +946,7 @@ pub fn unescape(input: &str) -> Cow<str> {
     let bytes = input.as_bytes();
     while i < input.len() {
         match bytes[i] {
-            b'\\' if (bytes[i + 1] as char).is_ascii_punctuation() => {
+            b'\\' if i + 1 < input.len() && (bytes[i + 1] as char).is_ascii_punctuation() => {
                 result.push_str(&input[mark..i]);
                 i += 1;
                 mark = i;

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -1005,20 +1005,21 @@ pub fn scan_html_type_7(data: &str) -> Option<usize> {
         return None;
     }
     i += l;
-    let n = scan_while(&data[i..], is_ascii_letterdigitdash);
-    i += n;
+    i += scan_while(&data[i..], is_ascii_letterdigitdash);
 
     if close_tag_bytes == 0 {
         loop {
-            i += scan_whitespace_no_nl(&data[i..]);
+            let whitespace = scan_whitespace_no_nl(&data[i..]);
+            i += whitespace;
             let c = data.as_bytes()[i];
             match c {
                 b'/' | b'>' => { 
                     break; },
                 _ => {},
             }
+            if whitespace == 0 { return None; }
             if let Some(a) = scan_attribute(&data[i..]) {
-                if a == 0 {break;}
+                if a == 0 { break; }
                 i += a;
             } else {
                 return None;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -170,8 +170,10 @@ impl<T: Default> Tree<T> {
     }
 
     /// Moves focus to the next sibling of the current focus.
-    pub fn next_sibling(&mut self) {
-        self.cur = self[self.cur.unwrap()].next;
+    pub fn next_sibling(&mut self) -> TreePointer {
+        let next = self[self.cur.unwrap()].next;
+        self.cur = next;
+        next
     }
 }
 


### PR DESCRIPTION
It took some convincing, but I now also see that doing things like this makes more sense ^^. The code should be much cleaner now. Upgrading to max performance should be a relatively small change from here, should we opt for it.

This PR additionally moves all remaining `ItemBody` variants to `Cow<str>`s, although some parsing functions may still only return `Owned` variants. I left this for now.

Again at 630/633.