### PR TITLE
Big merge preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ construct an AST. Another advantage is that source-map information (the mapping
 between parsed blocks and offsets within the source text) is readily available;
 you basically just call `get_offset()` as you consume events.
 
-While manipulating AST's is the most flexible way to transform documents,
+While manipulating ASTs is the most flexible way to transform documents,
 operating on iterators is surprisingly easy, and quite efficient. Here, for
 example, is the code to transform soft line breaks into hard breaks:
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -211,7 +211,7 @@ where
             Tag::Emphasis => self.write(b"<em>", false),
             Tag::Strong => self.write(b"<strong>", false),
             Tag::Code => self.write(b"<code>", false),
-            Tag::Link(dest, title) => {
+            Tag::Link(_link_type, dest, title) => {
                 self.write(b"<a href=\"", false)?;
                 escape_href(&mut self.writer, &dest)?;
                 if !title.is_empty() {
@@ -220,7 +220,7 @@ where
                 }
                 self.write(b"\">", false)
             }
-            Tag::Image(dest, title) => {
+            Tag::Image(_link_type, dest, title) => {
                 self.write(b"<img src=\"", false)?;
                 escape_href(&mut self.writer, &dest)?;
                 self.write(b"\" alt=\"", false)?;
@@ -301,10 +301,10 @@ where
             Tag::Code => {
                 self.write(b"</code>", false)?;
             }
-            Tag::Link(_, _) => {
+            Tag::Link(_, _, _) => {
                 self.write(b"</a>", false)?;
             }
-            Tag::Image(_, _) => (), // shouldn't happen, handled in start
+            Tag::Image(_, _, _) => (), // shouldn't happen, handled in start
             Tag::FootnoteDefinition(_) => {
                 self.write(b"</div>", true)?;
             }

--- a/src/html.rs
+++ b/src/html.rs
@@ -98,6 +98,7 @@ where
                 }
                 Text(text) => {
                     escape_html(&mut self.writer, &text, false)?;
+                    self.end_newline = text.ends_with('\n');
                 }
                 Html(html) | InlineHtml(html) => {
                     self.write(html.as_bytes(), false)?;
@@ -326,10 +327,12 @@ where
                 }
                 Text(text) => {
                     escape_html(&mut self.writer, &text, false)?;
+                    self.end_newline = text.ends_with('\n');
                 }
                 Html(_) => (),
                 InlineHtml(html) => {
                     escape_html(&mut self.writer, &html, false)?;
+                    self.end_newline = html.ends_with('\n');
                 }
                 SoftBreak | HardBreak => {
                     self.write(b" ", false)?;
@@ -377,7 +380,8 @@ where
     I: Iterator<Item = Event<'a>>,
 {
     unsafe {
-        let _ = write_html(s.as_mut_vec(), iter).unwrap();
+        // we only write utf-8, so this should be OK
+        write_html(s.as_mut_vec(), iter).unwrap();
     }
 }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -22,7 +22,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt::Write;
+use std::io::{self, Cursor, Write};
 
 use crate::parse::{Event, Tag, Alignment};
 use crate::parse::Event::*;
@@ -33,216 +33,325 @@ enum TableState {
     Body,
 }
 
-struct Ctx<'b, I> {
+struct HtmlWriter<'a, I, W>
+where
+    W: Write,
+{
+    /// Iterator supplying events.
     iter: I,
-    buf: &'b mut String,
+
+    /// Writer to write to.
+    writer: W,
+
+    /// Whether or not the last write wrote a newline.
+    end_newline: bool,
+
+    /// Number of bytes written.
+    bytes_written: usize,
+
     table_state: TableState,
     table_alignments: Vec<Alignment>,
     table_cell_index: usize,
+    numbers: HashMap<Cow<'a, str>, usize>,
 }
 
-impl<'a, 'b, I: Iterator<Item=Event<'a>>> Ctx<'b, I> {
-    fn fresh_line(&mut self) {
-        if !(self.buf.is_empty() || self.buf.ends_with('\n')) {
-            self.buf.push('\n');
+impl<'a, I, W> HtmlWriter<'a, I, W>
+where
+    I: Iterator<Item = Event<'a>>,
+    W: Write,
+{
+    /// Writes a new line.
+    fn write_newline(&mut self) -> io::Result<()> {
+        self.end_newline = true;
+        self.bytes_written += 1;
+
+        self.writer.write_all(&[b'\n'])
+    }
+
+    /// Writes a buffer, and tracks the number of bytes written,
+    /// and whether or not a newline was written.
+    fn write(&mut self, bytes: &[u8], write_newline: bool) -> io::Result<()> {
+        self.writer.write_all(bytes)?;
+        self.bytes_written += bytes.len();
+
+        if write_newline {
+            self.write_newline()
+        } else {
+            if bytes.len() > 0 {
+                self.end_newline = bytes[bytes.len() - 1] == b'\n';
+            }
+            Ok(())
         }
     }
 
-    pub fn run(&mut self) {
-        let mut numbers = HashMap::new();
+    /// Writes a newline if data was already written to the output stream,
+    /// and the previous line did not end with a newline.
+    fn fresh_line(&mut self) -> io::Result<()> {
+        if self.bytes_written > 0 && !self.end_newline {
+            self.write_newline()
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn run(mut self) -> io::Result<usize> {
         while let Some(event) = self.iter.next() {
             match event {
-                Start(tag) => self.start_tag(tag, &mut numbers),
-                End(tag) => self.end_tag(tag),
-                Text(text) => escape_html(self.buf, &text, false),
-                Html(html) |
-                InlineHtml(html) => self.buf.push_str(&html),
-                SoftBreak => self.buf.push('\n'),
-                HardBreak => self.buf.push_str("<br />\n"),
+                Start(tag) => {
+                    self.start_tag(tag)?;
+                }
+                End(tag) => {
+                    self.end_tag(tag)?;
+                }
+                Text(text) => {
+                    self.bytes_written += escape_html(&mut self.writer, &text, false)?;
+                }
+                Html(html) | InlineHtml(html) => {
+                    self.write(html.as_bytes(), false)?;
+                    self.end_newline = html.ends_with('\n');
+                }
+                SoftBreak => {
+                    self.write_newline()?;
+                }
+                HardBreak => {
+                    self.write(b"<br />", true)?;
+                }
                 FootnoteReference(name) => {
-                    let len = numbers.len() + 1;
-                    self.buf.push_str("<sup class=\"footnote-reference\"><a href=\"#");
-                    escape_html(self.buf, &*name, false);
-                    self.buf.push_str("\">");
-                    let number = numbers.entry(name).or_insert(len);
-                    self.buf.push_str(&*format!("{}", number));
-                    self.buf.push_str("</a></sup>");
-                },
+                    let len = self.numbers.len() + 1;
+                    self.write(b"<sup class=\"footnote-reference\"><a href=\"#", false)?;
+                    self.bytes_written += escape_html(&mut self.writer, &name, false)?;
+                    self.write(b"\">", false)?;
+                    let number = *self.numbers.entry(name).or_insert(len);
+                    self.write(format!("{}", number).as_bytes(), false)?;
+                    self.write(b"</a></sup>", false)?
+                }
             }
         }
+
+        Ok(self.bytes_written)
     }
 
-    fn start_tag(&mut self, tag: Tag<'a>, numbers: &mut HashMap<Cow<'a, str>, usize>) {
+    /// Writes the start of an HTML tag.
+    fn start_tag(&mut self, tag: Tag<'a>) -> io::Result<()> {
         match tag {
-            Tag::Paragraph =>  {
-                self.fresh_line();
-                self.buf.push_str("<p>");
+            Tag::Paragraph => {
+                self.fresh_line()?;
+                self.write(b"<p>", false)?;
             }
             Tag::Rule => {
-                self.fresh_line();
-                self.buf.push_str("<hr />\n")
+                self.fresh_line()?;
+                self.write(b"<hr />", true)?;
             }
             Tag::Header(level) => {
-                self.fresh_line();
-                self.buf.push_str("<h");
-                self.buf.push((b'0' + level as u8) as char);
-                self.buf.push('>');
+                self.fresh_line()?;
+                self.write(b"<h", false)?;
+                self.write(&[(b'0' + level as u8)], false)?;
+                self.write(b">", false)?;
             }
             Tag::Table(alignments) => {
                 self.table_alignments = alignments;
-                self.buf.push_str("<table>");
+                self.write(b"<table>", false)?;
             }
             Tag::TableHead => {
                 self.table_state = TableState::Head;
-                self.buf.push_str("<thead><tr>");
+                self.write(b"<thead><tr>", false)?;
             }
             Tag::TableRow => {
                 self.table_cell_index = 0;
-                self.buf.push_str("<tr>");
+                self.write(b"<tr>", false)?;
             }
             Tag::TableCell => {
                 match self.table_state {
-                    TableState::Head => self.buf.push_str("<th"),
-                    TableState::Body => self.buf.push_str("<td"),
+                    TableState::Head => {
+                        self.write(b"<th", false)?;
+                    }
+                    TableState::Body => {
+                        self.write(b"<td", false)?;
+                    }
                 }
                 match self.table_alignments.get(self.table_cell_index) {
-                    Some(&Alignment::Left) => self.buf.push_str(" align=\"left\""),
-                    Some(&Alignment::Center) => self.buf.push_str(" align=\"center\""),
-                    Some(&Alignment::Right) => self.buf.push_str(" align=\"right\""),
+                    Some(&Alignment::Left) => {
+                        self.write(b" align=\"left\"", false)?;
+                    }
+                    Some(&Alignment::Center) => {
+                        self.write(b" align=\"center\"", false)?;
+                    }
+                    Some(&Alignment::Right) => {
+                        self.write(b" align=\"right\"", false)?;
+                    }
                     _ => (),
                 }
-                self.buf.push_str(">");
+                self.write(b">", false)?;
             }
             Tag::BlockQuote => {
-                self.fresh_line();
-                self.buf.push_str("<blockquote>\n");
+                self.fresh_line()?;
+                self.write(b"<blockquote>", true)?;
             }
             Tag::CodeBlock(info) => {
-                self.fresh_line();
+                self.fresh_line()?;
                 let lang = info.split(' ').next().unwrap();
                 if lang.is_empty() {
-                    self.buf.push_str("<pre><code>");
+                    self.write(b"<pre><code>", false)?;
                 } else {
-                    self.buf.push_str("<pre><code class=\"language-");
-                    escape_html(self.buf, lang, false);
-                    self.buf.push_str("\">");
+                    self.write(b"<pre><code class=\"language-", false)?;
+                    self.bytes_written += escape_html(&mut self.writer, lang, false)?;
+                    self.write(b"\">", false)?;
                 }
             }
             Tag::List(Some(1)) => {
-                self.fresh_line();
-                self.buf.push_str("<ol>\n");
+                self.fresh_line()?;
+                self.write(b"<ol>", true)?;
             }
             Tag::List(Some(start)) => {
-                self.fresh_line();
-                let _ = writeln!(self.buf, "<ol start=\"{}\">", start);
+                self.fresh_line()?;
+                self.write(b"<ol start=\"", false)?;
+                self.write(format!("{}", start).as_bytes(), false)?;
+                self.write(b"\">", true)?;
             }
             Tag::List(None) => {
-                self.fresh_line();
-                self.buf.push_str("<ul>\n");
+                self.fresh_line()?;
+                self.write(b"<ul>", true)?;
             }
             Tag::Item => {
-                self.fresh_line();
-                self.buf.push_str("<li>");
+                self.fresh_line()?;
+                self.write(b"<li>", false)?;
             }
-            Tag::Emphasis => self.buf.push_str("<em>"),
-            Tag::Strong => self.buf.push_str("<strong>"),
-            Tag::Code => self.buf.push_str("<code>"),
+            Tag::Emphasis => self.write(b"<em>", false)?,
+            Tag::Strong => self.write(b"<strong>", false)?,
+            Tag::Code => self.write(b"<code>", false)?,
             Tag::Link(dest, title) => {
-                self.buf.push_str("<a href=\"");
-                escape_href(self.buf, &dest);
+                self.write(b"<a href=\"", false)?;
+                self.bytes_written += escape_href(&mut self.writer, &dest)?;
                 if !title.is_empty() {
-                    self.buf.push_str("\" title=\"");
-                    escape_html(self.buf, &title, false);
+                    self.write(b"\" title=\"", false)?;
+                    self.bytes_written += escape_html(&mut self.writer, &title, false)?;
                 }
-                self.buf.push_str("\">");
+                self.write(b"\">", false)?;
             }
             Tag::Image(dest, title) => {
-                self.buf.push_str("<img src=\"");
-                escape_href(self.buf, &dest);
-                self.buf.push_str("\" alt=\"");
-                self.raw_text(numbers);
+                self.write(b"<img src=\"", false)?;
+                self.bytes_written += escape_href(&mut self.writer, &dest)?;
+                self.write(b"\" alt=\"", false)?;
+                self.raw_text()?;
                 if !title.is_empty() {
-                    self.buf.push_str("\" title=\"");
-                    escape_html(self.buf, &title, false);
+                    self.write(b"\" title=\"", false)?;
+                    self.bytes_written += escape_html(&mut self.writer, &title, false)?;
                 }
-                self.buf.push_str("\" />")
+                self.write(b"\" />", false)?;
             }
             Tag::FootnoteDefinition(name) => {
-                self.fresh_line();
-                let len = numbers.len() + 1;
-                self.buf.push_str("<div class=\"footnote-definition\" id=\"");
-                escape_html(self.buf, &*name, false);
-                self.buf.push_str("\"><sup class=\"footnote-definition-label\">");
-                let number = numbers.entry(name).or_insert(len);
-                self.buf.push_str(&*format!("{}", number));
-                self.buf.push_str("</sup>");
+                self.fresh_line()?;
+                let len = self.numbers.len() + 1;
+                self.write(b"<div class=\"footnote-definition\" id=\"", false)?;
+                self.bytes_written += escape_html(&mut self.writer, &*name, false)?;
+                self.write(b"\"><sup class=\"footnote-definition-label\">", false)?;
+                let number = *self.numbers.entry(name).or_insert(len);
+                self.write(&*format!("{}", number).as_bytes(), false)?;
+                self.write(b"</sup>", false)?;
             }
             Tag::HtmlBlock => {}
         }
+        Ok(())
     }
 
-    fn end_tag(&mut self, tag: Tag) {
+    fn end_tag(&mut self, tag: Tag) -> io::Result<()> {
         match tag {
-            Tag::Paragraph => self.buf.push_str("</p>\n"),
+            Tag::Paragraph => {
+                self.write(b"</p>", true)?;
+            }
             Tag::Rule => (),
             Tag::Header(level) => {
-                self.buf.push_str("</h");
-                self.buf.push((b'0' + level as u8) as char);
-                self.buf.push_str(">\n");
+                self.write(b"</h", false)?;
+                self.write(&[(b'0' + level as u8)], false)?;
+                self.write(b">", true)?;
             }
             Tag::Table(_) => {
-                self.buf.push_str("</tbody></table>\n");
+                self.write(b"</tbody></table>", true)?;
             }
             Tag::TableHead => {
-                self.buf.push_str("</tr></thead><tbody>\n");
+                self.write(b"</tr></thead><tbody>", true)?;
                 self.table_state = TableState::Body;
             }
             Tag::TableRow => {
-                self.buf.push_str("</tr>\n");
+                self.write(b"</tr>", true)?;
             }
             Tag::TableCell => {
                 match self.table_state {
-                    TableState::Head => self.buf.push_str("</th>"),
-                    TableState::Body => self.buf.push_str("</td>"),
+                    TableState::Head => {
+                        self.write(b"</th>", false)?;
+                    }
+                    TableState::Body => {
+                        self.write(b"</td>", false)?;
+                    }
                 }
                 self.table_cell_index += 1;
             }
-            Tag::BlockQuote => self.buf.push_str("</blockquote>\n"),
-            Tag::CodeBlock(_) => self.buf.push_str("</code></pre>\n"),
-            Tag::List(Some(_)) => self.buf.push_str("</ol>\n"),
-            Tag::List(None) => self.buf.push_str("</ul>\n"),
-            Tag::Item => self.buf.push_str("</li>\n"),
-            Tag::Emphasis => self.buf.push_str("</em>"),
-            Tag::Strong => self.buf.push_str("</strong>"),
-            Tag::Code => self.buf.push_str("</code>"),
-            Tag::Link(_, _) => self.buf.push_str("</a>"),
+            Tag::BlockQuote => {
+                self.write(b"</blockquote>", true)?;
+            }
+            Tag::CodeBlock(_) => {
+                self.write(b"</code></pre>", true)?;
+            }
+            Tag::List(Some(_)) => {
+                self.write(b"</ol>", true)?;
+            }
+            Tag::List(None) => {
+                self.write(b"</ul>", true)?;
+            }
+            Tag::Item => {
+                self.write(b"</li>", true)?;
+            }
+            Tag::Emphasis => {
+                self.write(b"</em>", false)?;
+            }
+            Tag::Strong => {
+                self.write(b"</strong>", false)?;
+            }
+            Tag::Code => {
+                self.write(b"</code>", false)?;
+            }
+            Tag::Link(_, _) => {
+                self.write(b"</a>", false)?;
+            }
             Tag::Image(_, _) => (), // shouldn't happen, handled in start
-            Tag::FootnoteDefinition(_) => self.buf.push_str("</div>\n"),
+            Tag::FootnoteDefinition(_) => {
+                self.write(b"</div>", true)?;
+            }
             Tag::HtmlBlock => {}
         }
+        Ok(())
     }
 
     // run raw text, consuming end tag
-    fn raw_text<'c>(&mut self, numbers: &'c mut HashMap<Cow<'a, str>, usize>) {
+    fn raw_text<'c>(&mut self) -> io::Result<()> {
         let mut nest = 0;
         while let Some(event) = self.iter.next() {
             match event {
                 Start(_) => nest += 1,
                 End(_) => {
-                    if nest == 0 { break; }
+                    if nest == 0 {
+                        break;
+                    }
                     nest -= 1;
                 }
-                Text(text) => escape_html(self.buf, &text, false),
+                Text(text) => {
+                    self.bytes_written += escape_html(&mut self.writer, &text, false)?;
+                }
                 Html(_) => (),
-                InlineHtml(html) => escape_html(self.buf, &html, false),
-                SoftBreak | HardBreak => self.buf.push(' '),
+                InlineHtml(html) => {
+                    self.bytes_written += escape_html(&mut self.writer, &html, false)?;
+                }
+                SoftBreak | HardBreak => {
+                    self.write(b" ", false)?;
+                }
                 FootnoteReference(name) => {
-                    let len = numbers.len() + 1;
-                    let number = numbers.entry(name).or_insert(len);
-                    self.buf.push_str(&*format!("[{}]", number));
+                    let len = self.numbers.len() + 1;
+                    let number = *self.numbers.entry(name).or_insert(len);
+                    self.write(&*format!("[{}]", number).as_bytes(), false)?;
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -273,13 +382,57 @@ impl<'a, 'b, I: Iterator<Item=Event<'a>>> Ctx<'b, I> {
 /// </ul>
 /// "#);
 /// ```
-pub fn push_html<'a, I: Iterator<Item=Event<'a>>>(buf: &mut String, iter: I) {
-    let mut ctx = Ctx {
+pub fn push_html<'a, I>(s: &mut String, iter: I)
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    let mut buf = Vec::with_capacity(s.capacity());
+    let _ = write_html(Cursor::new(&mut buf), iter).unwrap();
+    s.push_str(&String::from_utf8_lossy(&buf));
+}
+
+/// Iterate over an `Iterator` of `Event`s, generate HTML for each `Event`, and
+/// write it out to a writable stream.
+///
+/// # Examples
+///
+/// ```
+/// use pulldown_cmark::{html, Parser};
+/// use std::io::Cursor;
+///
+/// let markdown_str = r#"
+/// hello
+/// =====
+///
+/// * alpha
+/// * beta
+/// "#;
+/// let mut bytes = Vec::new();
+/// let parser = Parser::new(markdown_str);
+///
+/// html::write_html(Cursor::new(&mut bytes), parser);
+///
+/// assert_eq!(&String::from_utf8_lossy(&bytes)[..], r#"<h1>hello</h1>
+/// <ul>
+/// <li>alpha</li>
+/// <li>beta</li>
+/// </ul>
+/// "#);
+/// ```
+pub fn write_html<'a, I, W>(writer: W, iter: I) -> io::Result<usize>
+where
+    I: Iterator<Item = Event<'a>>,
+    W: Write,
+{
+    let writer = HtmlWriter {
         iter: iter,
-        buf: buf,
+        writer: writer,
+        bytes_written: 0,
+        end_newline: false,
         table_state: TableState::Head,
         table_alignments: vec![],
         table_cell_index: 0,
+        numbers: HashMap::new(),
     };
-    ctx.run();
+    writer.run()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,4 +41,4 @@ mod parse;
 mod tree;
 mod linklabel;
 
-pub use crate::parse::{Parser, Alignment, Event, Tag, Options};
+pub use crate::parse::{Parser, Alignment, Event, Tag, Options, LinkType};

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,8 @@ pub fn main() {
         } else if matches.opt_present("dry-run") {
             dry_run(&input, opts);
         } else {
-            print!("{}", render_html(&input, opts));
+            let p = Parser::new_ext(&input, opts);
+            html::write_html(io::stdout(), p).unwrap();
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -58,11 +58,32 @@ pub enum Tag<'a> {
     Strong,
     Code,
 
-    /// A link. The first field is the destination URL and the second is a title
-    Link(Cow<'a, str>, Cow<'a, str>),
+    /// A link. The first field is the link type, the second the destination URL and the third is a title
+    Link(LinkType, Cow<'a, str>, Cow<'a, str>),
 
-    /// An image. The first field is the destination URL and the second is a title
-    Image(Cow<'a, str>, Cow<'a, str>),
+    /// An image. The first field is the link type, the second the destination URL and the third is a title
+    Image(LinkType, Cow<'a, str>, Cow<'a, str>),
+}
+
+// FIXME: Unknown variants are currently unused!
+#[derive(Clone, Debug, PartialEq, Copy)]
+pub enum LinkType {
+    /// Inline link like `[foo](bar)`
+    Inline,
+    /// Reference link like `[foo][bar]`
+    Reference,
+    /// Reference without destination in the document, but resolved by the broken_link_callback
+    ReferenceUnknown,
+    /// Collapsed link like `[foo][]`
+    Collapsed,
+    /// Collapsed link without destination in the document, but resolved by the broken_link_callback
+    CollapsedUnknown,
+    /// Shortcut link like `[foo]`
+    Shortcut,
+    /// Shortcut without destination in the document, but resolved by the broken_link_callback
+    ShortcutUnknown,
+    /// Autolink like `<http://foo.bar/baz>`
+    Autolink,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -124,8 +145,8 @@ enum ItemBody<'a> {
     Code,
     InlineHtml,
     // Link params: destination, title.
-    Link(Cow<'a, str>, Cow<'a, str>),
-    Image(Cow<'a, str>, Cow<'a, str>),
+    Link(LinkType, Cow<'a, str>, Cow<'a, str>),
+    Image(LinkType, Cow<'a, str>, Cow<'a, str>),
     FootnoteReference(Cow<'a, str>), // label
 
     Rule,
@@ -2189,7 +2210,7 @@ impl<'a> Parser<'a> {
                             end: ix - 1,
                             body: ItemBody::Text,
                         });
-                        self.tree[cur_ix].item.body = ItemBody::Link(uri, "".into());
+                        self.tree[cur_ix].item.body = ItemBody::Link(LinkType::Autolink, uri, "".into());
                         self.tree[cur_ix].item.end = ix;
                         self.tree[cur_ix].next = node;
                         self.tree[cur_ix].child = TreePointer::Valid(text_node);
@@ -2255,9 +2276,9 @@ impl<'a> Parser<'a> {
                             cur = TreePointer::Valid(tos.node);
                             cur_ix = tos.node;
                             self.tree[cur_ix].item.body = if tos.ty == LinkStackTy::Image {
-                                ItemBody::Image(url.into(), title.into())
+                                ItemBody::Image(LinkType::Inline, url.into(), title.into())
                             } else {
-                                ItemBody::Link(url.into(), title.into())
+                                ItemBody::Link(LinkType::Inline, url.into(), title.into())
                             };
                             self.tree[cur_ix].child = self.tree[cur_ix].next;
                             self.tree[cur_ix].next = next_node;
@@ -2284,6 +2305,11 @@ impl<'a> Parser<'a> {
                                 RefScan::Collapsed(next_node) => next_node,
                                 RefScan::Failed => next,
                             };
+                            let link_type = match &scan_result {
+                                RefScan::LinkLabel(..) => LinkType::Reference,
+                                RefScan::Collapsed(..) => LinkType::Collapsed,
+                                RefScan::Failed => LinkType::Shortcut,
+                            };
                             let label: Option<ReferenceLabel<'a>> = match scan_result {
                                 RefScan::LinkLabel(l, ..) => Some(ReferenceLabel::Link(l)),
                                 RefScan::Collapsed(..) | RefScan::Failed => {
@@ -2306,7 +2332,6 @@ impl<'a> Parser<'a> {
                                 link_stack.clear();
                                 continue;
                             }
-
                             // TODO(performance): make sure we aren't doing unnecessary allocations
                             // for the label
                             else if let Some(matching_def) = label.and_then(|l| match l { ReferenceLabel::Link(l) => Some(l), _ => None, })
@@ -2315,9 +2340,9 @@ impl<'a> Parser<'a> {
                                 let title = matching_def.title.as_ref().cloned().unwrap_or("".into());
                                 let url = matching_def.dest.clone();
                                 self.tree[tos.node].item.body = if tos.ty == LinkStackTy::Image {
-                                    ItemBody::Image(url, title)
+                                    ItemBody::Image(link_type, url, title)
                                 } else {
-                                    ItemBody::Link(url, title)
+                                    ItemBody::Link(link_type, url, title)
                                 };
 
                                 // lets do some tree surgery to add the link to the tree
@@ -2456,10 +2481,10 @@ fn item_to_tag<'a>(item: &Item<'a>) -> Option<Tag<'a>> {
         ItemBody::Code => Some(Tag::Code),
         ItemBody::Emphasis => Some(Tag::Emphasis),
         ItemBody::Strong => Some(Tag::Strong),
-        ItemBody::Link(ref url, ref title) =>
-            Some(Tag::Link(url.clone(), title.clone())),
-        ItemBody::Image(ref url, ref title) =>
-            Some(Tag::Image(url.clone(), title.clone())),
+        ItemBody::Link(ref link_type, ref url, ref title) =>
+            Some(Tag::Link(*link_type, url.clone(), title.clone())),
+        ItemBody::Image(ref link_type, ref url, ref title) =>
+            Some(Tag::Image(*link_type, url.clone(), title.clone())),
         ItemBody::Rule => Some(Tag::Rule),
         ItemBody::Header(level) => Some(Tag::Header(level)),
         ItemBody::FencedCodeBlock(ref info_string) =>

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -58,10 +58,10 @@ pub enum Tag<'a> {
     Strong,
     Code,
 
-    /// A link. The first field is the destination URL, the second is a title
+    /// A link. The first field is the destination URL and the second is a title
     Link(Cow<'a, str>, Cow<'a, str>),
 
-    /// An image. The first field is the destination URL, the second is a title
+    /// An image. The first field is the destination URL and the second is a title
     Image(Cow<'a, str>, Cow<'a, str>),
 }
 

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -30,13 +30,12 @@ use crate::parse::Alignment;
 pub use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 
 // sorted for binary search
-const HTML_TAGS: [&'static str; 50] = ["article", "aside", "blockquote",
+const HTML_TAGS: [&'static str; 47] = ["article", "aside", "blockquote",
     "body", "button", "canvas", "caption", "col", "colgroup", "dd", "div",
     "dl", "dt", "embed", "fieldset", "figcaption", "figure", "footer", "form",
     "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "iframe",
-    "li", "map", "object", "ol", "output", "p", "pre", "progress", "script",
-    "section", "style", "table", "tbody", "td", "textarea", "tfoot", "th",
-    "thead", "tr", "ul", "video"];
+    "li", "map", "object", "ol", "output", "p", "progress","section", "table",
+    "tbody", "td", "textarea", "tfoot", "th", "thead", "tr", "ul", "video"];
 
 /// Analysis of the beginning of a line, including indentation and container
 /// markers.

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -29,6 +29,15 @@ use crate::parse::Alignment;
 
 pub use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 
+// sorted for binary search
+const HTML_TAGS: [&'static str; 50] = ["article", "aside", "blockquote",
+    "body", "button", "canvas", "caption", "col", "colgroup", "dd", "div",
+    "dl", "dt", "embed", "fieldset", "figcaption", "figure", "footer", "form",
+    "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "iframe",
+    "li", "map", "object", "ol", "output", "p", "pre", "progress", "script",
+    "section", "style", "table", "tbody", "td", "textarea", "tfoot", "th",
+    "thead", "tr", "ul", "video"];
+
 /// Analysis of the beginning of a line, including indentation and container
 /// markers.
 #[derive(Clone)]
@@ -200,15 +209,6 @@ impl<'a> LineStart<'a> {
         self.spaces_remaining
     }
 }
-
-// sorted for binary search
-const HTML_TAGS: [&'static str; 50] = ["article", "aside", "blockquote",
-    "body", "button", "canvas", "caption", "col", "colgroup", "dd", "div",
-    "dl", "dt", "embed", "fieldset", "figcaption", "figure", "footer", "form",
-    "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "iframe",
-    "li", "map", "object", "ol", "output", "p", "pre", "progress", "script",
-    "section", "style", "table", "tbody", "td", "textarea", "tfoot", "th",
-    "thead", "tr", "ul", "video"];
 
 pub fn is_ascii_whitespace(c: u8) -> bool {
     (c >= 0x09 && c <= 0x0d) || c == b' '
@@ -627,6 +627,29 @@ pub fn scan_link_dest(data: &str) -> Option<(usize, &str)> {
     Some((i, &data[dest_beg..dest_end]))
 }
 
+pub fn scan_attribute_name(data: &str) -> Option<usize> {
+    let size = data.len();
+    if size == 0 { 
+        return None; }
+    match data.as_bytes()[0] {
+        c if is_ascii_alpha(c) => (),
+        b'_' | b':' => (),
+        _ => {
+   
+            return None;
+        }
+    }
+    let mut i = 1;
+    while i < size {
+        match data.as_bytes()[i] {
+            c if is_ascii_alphanumeric(c) => i += 1,
+            b'_' | b'.' | b':' | b'-' => i += 1,
+            _ => break
+        }
+    }
+    Some(i)
+}
+
 pub fn scan_attribute_value(data: &str) -> Option<usize> {
     let size = data.len();
     if size == 0 { return None; }
@@ -759,29 +782,6 @@ pub fn scan_html_type_7(data: &str) -> Option<usize> {
     } else {
         return None;
     }
-}
-
-pub fn scan_attribute_name(data: &str) -> Option<usize> {
-    let size = data.len();
-    if size == 0 { 
-        return None; }
-    match data.as_bytes()[0] {
-        c if is_ascii_alpha(c) => (),
-        b'_' | b':' => (),
-        _ => {
-   
-            return None;
-        }
-    }
-    let mut i = 1;
-    while i < size {
-        match data.as_bytes()[i] {
-            c if is_ascii_alphanumeric(c) => i += 1,
-            b'_' | b'.' | b':' | b'-' => i += 1,
-            _ => break
-        }
-    }
-    Some(i)
 }
 
 pub fn scan_attribute(data: &str) -> Option<usize> {

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -29,18 +29,6 @@ use crate::parse::Alignment;
 
 pub use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 
-// sorted for binary_search
-const HTML_TAGS: [&'static str; 72] = ["address", "article", "aside", "base", 
-    "basefont", "blockquote", "body", "button", "canvas", "caption", "center",
-    "col", "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt", 
-    "embed", "fieldset", "figcaption", "figure", "footer", "form", "frame", 
-    "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", 
-    "hr", "html", "iframe", "legend", "li", "link", "main", "menu", "menuitem", 
-    "meta", "map", "nav", "noframes", "object", "ol", "optgroup", "option", 
-    "output", "p", "param", "progress", "section", "source", "summary", 
-    "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "title", "tr", 
-    "ul", "video"];
-
 /// Analysis of the beginning of a line, including indentation and container
 /// markers.
 #[derive(Clone)]
@@ -212,6 +200,15 @@ impl<'a> LineStart<'a> {
         self.spaces_remaining
     }
 }
+
+// sorted for binary search
+const HTML_TAGS: [&'static str; 50] = ["article", "aside", "blockquote",
+    "body", "button", "canvas", "caption", "col", "colgroup", "dd", "div",
+    "dl", "dt", "embed", "fieldset", "figcaption", "figure", "footer", "form",
+    "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "iframe",
+    "li", "map", "object", "ol", "output", "p", "pre", "progress", "script",
+    "section", "style", "table", "tbody", "td", "textarea", "tfoot", "th",
+    "thead", "tr", "ul", "video"];
 
 pub fn is_ascii_whitespace(c: u8) -> bool {
     (c >= 0x09 && c <= 0x0d) || c == b' '
@@ -630,29 +627,6 @@ pub fn scan_link_dest(data: &str) -> Option<(usize, &str)> {
     Some((i, &data[dest_beg..dest_end]))
 }
 
-pub fn scan_attribute_name(data: &str) -> Option<usize> {
-    let size = data.len();
-    if size == 0 { 
-        return None; }
-    match data.as_bytes()[0] {
-        c if is_ascii_alpha(c) => (),
-        b'_' | b':' => (),
-        _ => {
-   
-            return None;
-        }
-    }
-    let mut i = 1;
-    while i < size {
-        match data.as_bytes()[i] {
-            c if is_ascii_alphanumeric(c) => i += 1,
-            b'_' | b'.' | b':' | b'-' => i += 1,
-            _ => break
-        }
-    }
-    Some(i)
-}
-
 pub fn scan_attribute_value(data: &str) -> Option<usize> {
     let size = data.len();
     if size == 0 { return None; }
@@ -785,6 +759,29 @@ pub fn scan_html_type_7(data: &str) -> Option<usize> {
     } else {
         return None;
     }
+}
+
+pub fn scan_attribute_name(data: &str) -> Option<usize> {
+    let size = data.len();
+    if size == 0 { 
+        return None; }
+    match data.as_bytes()[0] {
+        c if is_ascii_alpha(c) => (),
+        b'_' | b':' => (),
+        _ => {
+   
+            return None;
+        }
+    }
+    let mut i = 1;
+    while i < size {
+        match data.as_bytes()[i] {
+            c if is_ascii_alphanumeric(c) => i += 1,
+            b'_' | b'.' | b':' | b'-' => i += 1,
+            _ => break
+        }
+    }
+    Some(i)
 }
 
 pub fn scan_attribute(data: &str) -> Option<usize> {

--- a/tests/normalize_html.rs.inc
+++ b/tests/normalize_html.rs.inc
@@ -256,7 +256,6 @@ fn normalize_node(parent: &Handle, node: &mut Handle) -> bool {
                         !contents.borrow().chars().all(|c| c.is_whitespace())
                     }
                     _ => {
-                        dbg!("smth else");
                         true
                     }
                 }).unwrap_or(false)


### PR DESCRIPTION
This merges master into new_algo and lays the groundwork for the new_algo -> master merge. There were no big conflicts.

There were two issues that I found:
 * the `push_html` function in the master branch writes the entire output to an intermediate buffer before copying all that to the given target string. This, together with ...
 * ... manual written byte counting seemed to incur a ~30% performance loss.

By writing to the string directly and foregoing manual byte counting, the performance regression from new_algo is limited to ~5%. Since we only push utf-8 to the output buffer, this should be safe. For those interested in the number of bytes written, it's easy to wrap a writer with an implementation of `Seek` - which should be faster to boot. This would be a breaking change.

Open to input of course!