### PR TITLE
String experiment for faster unescaping

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -6,9 +6,6 @@ extern crate test;
 mod to_html {
     use pulldown_cmark::{Parser, Options, html};
     use std::str::from_utf8;
-    use std::io::Read;
-    use std::path::Path;
-    use std::fs::File;
 
     fn render_html(text: &str, opts: Options) -> String {
         let mut s = String::with_capacity(text.len() * 3 / 2);
@@ -21,6 +18,21 @@ mod to_html {
     fn crdt_empty_options(b: &mut test::Bencher) {
         let input_bytes = include_bytes!("crdt.md");
         let input = from_utf8(input_bytes).unwrap();
+        let mut opts = Options::empty();
+
+        b.iter(|| render_html(&input, opts));
+    }
+
+    #[bench]
+    fn paragraph_lots_unescapes(b: &mut test::Bencher) {
+        let input = "This is by far my favourite unicode code point: &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;
+        &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;
+        &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;
+        &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;
+        &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;
+        &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;
+        &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;
+        &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA; &#xAAA;";
         let mut opts = Options::empty();
 
         b.iter(|| render_html(&input, opts));

--- a/src/html.rs
+++ b/src/html.rs
@@ -26,6 +26,7 @@ use std::io::{self, Write};
 
 use crate::parse::{LinkType, Event, Tag, Alignment};
 use crate::parse::Event::*;
+use crate::strings::CowStr;
 use crate::escape::{escape_html, escape_href};
 
 enum TableState {
@@ -49,7 +50,7 @@ where
     table_state: TableState,
     table_alignments: Vec<Alignment>,
     table_cell_index: usize,
-    numbers: HashMap<Cow<'a, str>, usize>,
+    numbers: HashMap<CowStr<'a>, usize>,
 }
 
 impl<'a, I, W> HtmlWriter<'a, I, W>

--- a/src/html.rs
+++ b/src/html.rs
@@ -20,7 +20,6 @@
 
 //! HTML renderer that takes an iterator of events as input.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{self, Write};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,5 +40,6 @@ mod utils;
 mod parse;
 mod tree;
 mod linklabel;
+mod strings;
 
 pub use crate::parse::{Parser, Alignment, Event, Tag, Options, LinkType};

--- a/src/linklabel.rs
+++ b/src/linklabel.rs
@@ -20,8 +20,6 @@
 
 //! Link label parsing and matching.
 
-use std::borrow::Cow;
-
 use unicase::UniCase;
 
 use crate::strings::CowStr;

--- a/src/linklabel.rs
+++ b/src/linklabel.rs
@@ -24,12 +24,14 @@ use std::borrow::Cow;
 
 use unicase::UniCase;
 
+use crate::strings::CowStr;
+
 pub enum ReferenceLabel<'a> {
-    Link(Cow<'a, str>),
-    Footnote(Cow<'a, str>),
+    Link(CowStr<'a>),
+    Footnote(CowStr<'a>),
 }
 
-pub type LinkLabel<'a> = UniCase<Cow<'a, str>>;
+pub type LinkLabel<'a> = UniCase<CowStr<'a>>;
 
 /// Returns number of bytes (including brackets) and label on success.
 pub(crate) fn scan_link_label<'a>(text: &'a str) -> Option<(usize, ReferenceLabel<'a>)> {
@@ -46,7 +48,7 @@ pub(crate) fn scan_link_label<'a>(text: &'a str) -> Option<(usize, ReferenceLabe
 
 /// Assumes the opening bracket has already been scanned.
 /// Returns the number of bytes read (including closing bracket) and label on success.
-pub(crate) fn scan_link_label_rest<'a>(text: &'a str) -> Option<(usize, Cow<'a, str>)> {
+pub(crate) fn scan_link_label_rest<'a>(text: &'a str) -> Option<(usize, CowStr<'a>)> {
     let mut char_iter = text.chars().peekable();
     let mut byte_index = 0;
     let mut only_white_space = true;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,7 +20,7 @@
 
 //! Tree-based two pass parser.
 
-use std::borrow::Cow::{self, Borrowed};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use unicase::UniCase;
@@ -684,8 +684,6 @@ impl<'a> FirstPass<'a> {
                     begin_text = ix;
                 }
                 b'&' => {
-                    // TODO(performance): if owned, entity will always just be a char,
-                    // which we should be able to store without allocating
                     match scan_entity(&self.text[ix..]) {
                         (n, Some(value)) => {
                             self.tree.append_text(begin_text, ix);
@@ -2605,5 +2603,17 @@ impl<'a> Iterator for Parser<'a> {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tree::Node;
+
+    #[test]
+    fn node_size() {
+        let node_size = std::mem::size_of::<Node<Item>>();
+        assert_eq!(104, node_size);
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,7 +20,6 @@
 
 //! Tree-based two pass parser.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 use unicase::UniCase;
@@ -1342,33 +1341,23 @@ fn count_header_cols(text: &str, mut pipes: usize, mut start: usize, last_pipe_i
 
 fn unescape_cow<'a>(c: CowStr<'a>) -> CowStr<'a> {
     match c {
-        CowStr::Inlined(s) => {
-            match unescape(s.as_ref()) {
-                CowStr::Borrowed(s) => {
-                    if let Ok(inline_str) = InlineStr::try_from_str(s) {
-                        CowStr::Inlined(inline_str)
-                    } else {
-                        s.to_owned().into()
-                    }
-                }
-                CowStr::Inlined(s) => CowStr::Inlined(s),
-                CowStr::Boxed(s) => CowStr::Boxed(s),
-            }
-        }
-        CowStr::Boxed(s) => {
-            match unescape(s.as_ref()) {
-                CowStr::Borrowed(s) => {
-                    if let Ok(inline_str) = InlineStr::try_from_str(s) {
-                        CowStr::Inlined(inline_str)
-                    } else {
-                        s.to_owned().into()
-                    }
-                }
-                CowStr::Inlined(s) => CowStr::Inlined(s),
-                CowStr::Boxed(s) => CowStr::Boxed(s),
-            }
-        }
+        CowStr::Inlined(s) => unescape_str_line(s),
+        CowStr::Boxed(s) => unescape_str_line(s),
         CowStr::Borrowed(s) => unescape(&s),
+    }
+}
+
+fn unescape_str_line<'a, S: AsRef<str>>(s: S) -> CowStr<'a> {
+    match unescape(s.as_ref()) {
+        CowStr::Borrowed(s) => {
+            if let Ok(inline_str) = InlineStr::try_from_str(s) {
+                CowStr::Inlined(inline_str)
+            } else {
+                s.to_owned().into()
+            }
+        }
+        CowStr::Inlined(s) => CowStr::Inlined(s),
+        CowStr::Boxed(s) => CowStr::Boxed(s),
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 
 use unicase::UniCase;
 
-use crate::strings::SmortStr;
+use crate::strings::CowStr;
 use crate::scanners::*;
 use crate::tree::{TreePointer, TreeIndex, Tree};
 use crate::linklabel::{scan_link_label, scan_link_label_rest, LinkLabel, ReferenceLabel};
@@ -91,7 +91,7 @@ pub enum LinkType {
 pub enum Event<'a> {
     Start(Tag<'a>),
     End(Tag<'a>),
-    Text(SmortStr<'a>),
+    Text(CowStr<'a>),
     Html(Cow<'a, str>),
     InlineHtml(Cow<'a, str>),
     FootnoteReference(Cow<'a, str>),
@@ -159,7 +159,7 @@ enum ItemBody<'a> {
     BlockQuote,
     List(bool, u8, Option<usize>), // is_tight, list character, list start index
     ListItem(usize), // indent level
-    SynthesizeText(SmortStr<'static>),
+    SynthesizeText(CowStr<'static>),
     FootnoteDefinition(Cow<'a, str>), // label
 
     // Tables

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -22,7 +22,6 @@
 
 use crate::entities;
 use crate::utils;
-use std::borrow::Cow::{self, Borrowed, Owned};
 use std::char;
 
 use crate::parse::Alignment;

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -22,11 +22,11 @@
 
 use crate::entities;
 use crate::utils;
-use std::borrow::Cow;
-use std::borrow::Cow::{Borrowed, Owned};
+use std::borrow::Cow::{self, Borrowed, Owned};
 use std::char;
-use crate::parse::Alignment;
 
+use crate::parse::Alignment;
+use crate::strings::SmortStr;
 pub use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 
 // sorted for binary search
@@ -541,16 +541,16 @@ pub fn scan_listitem(data: &str) -> (usize, u8, usize, usize) {
     (w + postn, c, start, w + postindent)
 }
 
-fn cow_from_codepoint_str(s: &str, radix: u32) -> Cow<'static, str> {
+fn char_from_codepoint_str(s: &str, radix: u32) -> char {
     let mut codepoint = u32::from_str_radix(s, radix).unwrap();
     if codepoint == 0 {
         codepoint = 0xFFFD;
     }
-    Owned(char::from_u32(codepoint).unwrap_or('\u{FFFD}').to_string())
+    char::from_u32(codepoint).unwrap_or('\u{FFFD}')
 }
 
 // doesn't bother to check data[0] == '&'
-pub fn scan_entity(data: &str) -> (usize, Option<Cow<'static, str>>) {
+pub fn scan_entity(data: &str) -> (usize, Option<SmortStr<'static>>) {
     let size = data.len();
     let mut end = 1;
     if scan_ch(&data[end..], b'#') == 1 {
@@ -559,12 +559,12 @@ pub fn scan_entity(data: &str) -> (usize, Option<Cow<'static, str>>) {
             end += 1;
             end += scan_while(&data[end..], is_hexdigit);
             if end > 3 && end < 12 && scan_ch(&data[end..], b';') == 1 {
-                return (end + 1, Some(cow_from_codepoint_str(&data[3..end], 16)));
+                return (end + 1, Some(char_from_codepoint_str(&data[3..end], 16).into()));
             }
         } else {
             end += scan_while(&data[end..], is_digit);
             if end > 2 && end < 11 && scan_ch(&data[end..], b';') == 1 {
-                return (end + 1, Some(cow_from_codepoint_str(&data[2..end], 10)));
+                return (end + 1, Some(char_from_codepoint_str(&data[2..end], 10).into()));
             }
         }
         return (0, None);
@@ -572,7 +572,7 @@ pub fn scan_entity(data: &str) -> (usize, Option<Cow<'static, str>>) {
     end += scan_while(&data[end..], is_ascii_alphanumeric);
     if scan_ch(&data[end..], b';') == 1 {
         if let Some(value) = entities::get_entity(&data[1..end]) {
-            return (end + 1, Some(Borrowed(value)));
+            return (end + 1, Some(value.into()));
         }
     }
     (0, None)

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -26,7 +26,7 @@ use std::borrow::Cow::{self, Borrowed, Owned};
 use std::char;
 
 use crate::parse::Alignment;
-use crate::strings::SmortStr;
+use crate::strings::CowStr;
 pub use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 
 // sorted for binary search
@@ -550,7 +550,7 @@ fn char_from_codepoint_str(s: &str, radix: u32) -> char {
 }
 
 // doesn't bother to check data[0] == '&'
-pub fn scan_entity(data: &str) -> (usize, Option<SmortStr<'static>>) {
+pub fn scan_entity(data: &str) -> (usize, Option<CowStr<'static>>) {
     let size = data.len();
     let mut end = 1;
     if scan_ch(&data[end..], b'#') == 1 {

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -676,7 +676,7 @@ pub fn scan_attribute_value(data: &str) -> Option<usize> {
 }
 
 // Remove backslash escapes and resolve entities
-pub fn unescape(input: &str) -> Cow<str> {
+pub fn unescape<'a>(input: &'a str) -> CowStr<'a> {
     let mut result = String::new();
     let mut mark = 0;
     let mut i = 0;
@@ -708,10 +708,10 @@ pub fn unescape(input: &str) -> Cow<str> {
         }
     }
     if mark == 0 {
-        Borrowed(input)
+        input.into()
     } else {
         result.push_str(&input[mark..]);
-        Owned(result)
+        result.into()
     }
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -16,6 +16,12 @@ pub struct InlineStr {
     inner: [u8; DOUBLE_WORD_SIZE],
 }
 
+impl<'a> AsRef<str> for InlineStr {
+    fn as_ref(&self) -> &str {
+        self.deref()
+    }
+}
+
 impl Hash for InlineStr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.deref().hash(state);

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 use std::borrow::{ToOwned, Borrow};
-use std::str::from_utf8_unchecked;
+use std::str::from_utf8;
 
 const DOUBLE_WORD_SIZE: usize = 2 * std::mem::size_of::<isize>();
 
@@ -50,9 +50,7 @@ impl Deref for InlineStr {
 
     fn deref(&self) -> &str {
         let len = self.inner[DOUBLE_WORD_SIZE - 1] as usize;
-        unsafe {
-            from_utf8_unchecked(&self.inner[..len])
-        }
+        from_utf8(&self.inner[..len]).unwrap()
     }
 }
 
@@ -118,7 +116,7 @@ impl<'a> Borrow<str> for CowStr<'a> {
 }
 
 impl<'a> CowStr<'a> {
-    fn to_string(self) -> String {
+    pub fn to_string(self) -> String {
         match self {
             CowStr::Boxed(b) => b.into(),
             CowStr::Borrowed(b) => b.to_owned(),

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,0 +1,105 @@
+use std::ops::Deref;
+use std::borrow::Borrow;
+use std::str::from_utf8_unchecked;
+
+#[derive(Debug, Clone, Copy)]
+pub struct StackStr {
+    inner: [u8; 4],
+    len: usize,
+}
+
+impl From<char> for StackStr {
+    fn from(c: char) -> Self {
+        let mut inner = [0u8; 4];
+        c.encode_utf8(&mut inner);
+        Self {
+            inner,
+            len: c.len_utf8(),
+        }
+    }
+}
+
+impl Deref for StackStr {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        unsafe {
+            from_utf8_unchecked(&self.inner[..self.len])
+        }
+    }
+}
+
+pub enum SmortStr<'a> {
+    Boxed(Box<str>),
+    Borrowed(&'a str),
+    Stacked(StackStr),
+}
+
+impl<'a> From<&'a str> for SmortStr<'a> {
+    fn from(s: &'a str) -> Self {
+        SmortStr::Borrowed(s)
+    }
+}
+
+impl<'a> From<String> for SmortStr<'a> {
+    fn from(s: String) -> Self {
+        SmortStr::Boxed(s.into_boxed_str())
+    }
+}
+
+impl<'a> From<char> for SmortStr<'a> {
+    fn from(c: char) -> Self {
+        SmortStr::Stacked(c.into())
+    }
+}
+
+impl<'a> Deref for SmortStr<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        match self {
+            SmortStr::Boxed(ref b) => &*b,
+            SmortStr::Borrowed(b) => b,
+            SmortStr::Stacked(ref s) => s.deref(),
+        }
+    }
+}
+
+impl<'a> Borrow<str> for SmortStr<'a> {
+    fn borrow(&self) -> &str {
+        self.deref()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn stackstr_ascii() {
+        let s: StackStr = 'a'.into();
+        assert_eq!("a", s.deref());
+    }
+
+    #[test]
+    fn stackstr_unicode() {
+        let s: StackStr = '🍔'.into();
+        assert_eq!("🍔", s.deref());
+    }
+
+    #[test]
+    fn smortstr_size() {
+        let size = std::mem::size_of::<SmortStr>();
+        let word_size = std::mem::size_of::<isize>();
+        assert_eq!(3 * word_size, size);
+    }
+
+    #[test]
+    fn smortstr_char_to_owned() {
+        let c = '藏';
+        let smort: SmortStr = c.into();
+        let owned: String = smort.to_owned();
+        let expected = "藏".to_owned();
+        assert_eq!(expected, owned);
+    }
+}


### PR DESCRIPTION
As promised, here is a quick proof of concept for a new string type. It has two benefits over `Cow<str>`:

1. it does not allocate for single characters, which are used exclusively for unescaping
2. it takes up three instead of four words of memory, which could shrink our `Node<Item>` type by 16 bytes on x64 which is currently determined by the `Link` and `Image` variants, containing two such values. Shrinking this datatype reduces the memory footprint and hence improves the L1 cache performance of our AST tree

Downsides: 
* custom string type is exposed in API, which breaks backwards compatibility. However, by implementing `Deref` and `Borrow`, it can be used as a `&str` much like `Cow<str>`. Note that in the PR we didn't need to touch any code consuming the events.

Performance:
* on input without unescapes, performance difference is currently too small to measure. When converting more cows, we could gain additional throughput through improved cachability as described above
* on a heavy unescaped output, of which one example has been added to the benchmark suite, iteration time dropped from 32,000ns -> 20,000ns on my machine

Is this enough of a jump to justify adding a custom string type? Let's discuss.  