### PR TITLE
Various optimizations

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -24,7 +24,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{self, Write};
 
-use crate::parse::{Event, Tag, Alignment};
+use crate::parse::{LinkType, Event, Tag, Alignment};
 use crate::parse::Event::*;
 use crate::escape::{escape_html, escape_href};
 
@@ -211,6 +211,15 @@ where
             Tag::Emphasis => self.write(b"<em>", false),
             Tag::Strong => self.write(b"<strong>", false),
             Tag::Code => self.write(b"<code>", false),
+            Tag::Link(LinkType::Email, dest, title) => {
+                self.write(b"<a href=\"mailto:", false)?;
+                escape_href(&mut self.writer, &dest)?;
+                if !title.is_empty() {
+                    self.write(b"\" title=\"", false)?;
+                    escape_html(&mut self.writer, &title, false)?;
+                }
+                self.write(b"\">", false)
+            }
             Tag::Link(_link_type, dest, title) => {
                 self.write(b"<a href=\"", false)?;
                 escape_href(&mut self.writer, &dest)?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1330,6 +1330,12 @@ fn unescape_cow<'a>(c: Cow<'a, str>) -> Cow<'a, str> {
 impl<'a> Tree<Item<'a>> {
     fn append_text(&mut self, start: usize, end: usize) {
         if end > start {
+            if let TreePointer::Valid(ix) = self.cur() {
+                if ItemBody::Text == self[ix].item.body && self[ix].item.end == start {
+                    self[ix].item.end = end;
+                    return;
+                }
+            }
             self.append(Item {
                 start: start,
                 end: end,


### PR DESCRIPTION
This does the following optimizations:
 * when appending text, checks if current node is a text node and tries to extend it. This ended up being pretty significant, dropping the render time on `crdt.md` from ~575µs → ~515µs on my machine
 * returning borrowed strings for refdef titles and autolinks whenever possible