### PR TITLE
Bump version, update readme, implement source offset method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "pulldown-cmark"
-# Note: This not a valid release, intended to be filled in when it's ready.
-version = "0.0.0"
+version = "0.3.0"
 authors = [ "Raph Levien <raph.levien@gmail.com>" ]
 license = "MIT"
 description = "A pull parser for CommonMark"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ serialized string.
 
 Pull parsing is in some sense the most versatile architecture. It's possible to
 drive a push interface, also with minimal memory, and quite straightforward to
-construct an AST.
+construct an AST. Another advantage is that source-map information (the mapping
+between parsed blocks and offsets within the source text) is readily available;
+you basically just call `get_offset()` as you consume events.
 
 While manipulating ASTs is the most flexible way to transform documents,
 operating on iterators is surprisingly easy, and quite efficient. Here, for

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ It is designed to be:
 * Versatile; in particular source-maps are supported
 * Correct; the goal is 100% compliance with the [CommonMark spec](http://spec.commonmark.org/)
 
+Further, it optionally supports parsing footnotes and
+[Github flavored tables](https://github.github.com/gfm/#tables-extension-).
+
 ## Why a pull parser?
 
 There are many parsers for Markdown and its variants, but to my knowledge none
@@ -32,9 +35,7 @@ serialized string.
 
 Pull parsing is in some sense the most versatile architecture. It's possible to
 drive a push interface, also with minimal memory, and quite straightforward to
-construct an AST. Another advantage is that source-map information (the mapping
-between parsed blocks and offsets within the source text) is readily available;
-you basically just call `get_offset()` as you consume events.
+construct an AST.
 
 While manipulating ASTs is the most flexible way to transform documents,
 operating on iterators is surprisingly easy, and quite efficient. Here, for
@@ -51,7 +52,7 @@ Or expanding an abbreviation in text:
 
 ```rust
 let parser = parser.map(|event| match event {
-	Event::Text(text) => Event::Text(text.replace("abbr", "abbreviation")),
+	Event::Text(text) => Event::Text(text.replace("abbr", "abbreviation").into()),
 	_ => event
 });
 ```
@@ -86,8 +87,8 @@ full power and expressivity of Rust's iterator infrastructure, including
 for loops and `map` (as in the examples above), collecting the events into
 a vector (for recording, playback, and manipulation), and more.
 
-Further, the `Text` event (representing text) is a copy-on-write string (note:
-this isn't quite true yet). The vast majority of text fragments are just
+Further, the `Text` event (representing text) is a small copy-on-write string.
+The vast majority of text fragments are just
 slices of the source document. For these, copy-on-write gives a convenient
 representation that requires no allocation or copying, but allocated
 strings are available when they're needed. Thus, when rendering text to
@@ -105,7 +106,7 @@ By default, the binary is built as well. If you don't want/need it, then build l
 Or put in your `Cargo.toml` file:
 
 ```toml
-pulldown-cmark = { version = "0.0.11", default-features = false }
+pulldown-cmark = { version = "0.3", default-features = false }
 ```
 
 ## Authors

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2200,6 +2200,7 @@ pub struct Parser<'a> {
     tree: Tree<Item<'a>>,
     refdefs: HashMap<LinkLabel<'a>, LinkDef<'a>>,
     broken_link_callback: Option<&'a Fn(&str, &str) -> Option<(String, String)>>,
+    offset: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -2224,11 +2225,11 @@ impl<'a> Parser<'a> {
         let first_pass = FirstPass::new(text, options);
         let (mut tree, refdefs) = first_pass.run();
         tree.reset();
-        Parser { text, tree, refdefs, broken_link_callback }
+        Parser { text, tree, refdefs, broken_link_callback, offset: 0 }
     }
 
     pub fn get_offset(&self) -> usize {
-        0  // TODO
+        self.offset
     }
 
     /// Handle inline markup.
@@ -2644,6 +2645,7 @@ impl<'a> Iterator for Parser<'a> {
             TreePointer::Nil => {
                 let ix = self.tree.pop()?;
                 let tag = item_to_tag(&self.tree[ix].item).unwrap();
+                self.offset = self.tree[ix].item.end;
                 self.tree.next_sibling();
                 return Some(Event::End(tag));
             }
@@ -2661,10 +2663,12 @@ impl<'a> Iterator for Parser<'a> {
 
         if let TreePointer::Valid(cur_ix) = self.tree.cur() {
             if let Some(tag) = item_to_tag(&self.tree[cur_ix].item) {
+                self.offset = self.tree[cur_ix].item.end;
                 self.tree.push();                
                 Some(Event::Start(tag))
             } else {
                 self.tree.next_sibling();
+                self.offset = self.tree[cur_ix].item.start;
                 Some(item_to_event(&self.tree[cur_ix].item, self.text))
             }
         } else {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2663,12 +2663,16 @@ impl<'a> Iterator for Parser<'a> {
 
         if let TreePointer::Valid(cur_ix) = self.tree.cur() {
             if let Some(tag) = item_to_tag(&self.tree[cur_ix].item) {
-                self.offset = self.tree[cur_ix].item.end;
+                self.offset = if let TreePointer::Valid(child_ix) = self.tree[cur_ix].child {
+                    self.tree[child_ix].item.start
+                } else {
+                    self.tree[cur_ix].item.end
+                };
                 self.tree.push();                
                 Some(Event::Start(tag))
             } else {
                 self.tree.next_sibling();
-                self.offset = self.tree[cur_ix].item.start;
+                self.offset = self.tree[cur_ix].item.end;
                 Some(item_to_event(&self.tree[cur_ix].item, self.text))
             }
         } else {


### PR DESCRIPTION
While going through the README, I found that `get_offset` was there to provide source mapping for blocks. However, it wasn't implemented yet. There is some ambiguity as how to do it for leaves; I've currently set the offset to their start, but setting it to their end seems just as feasible..