### PR TITLE
Consider unicode punctuation in delimiter run examination

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -53,3 +53,11 @@ ISSUE #145
 <tr><td>Content   </td><td>Content   </td><td>Conent    </td><td align="right">Content   </td></tr>
 </tbody></table>
 ````````````````````````````````
+
+Unicode punctuation and emphasis
+
+```````````````````````````````` example
+foo§__(bar)__
+.
+<p>foo§<strong>(bar)</strong></p>
+````````````````````````````````

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1407,13 +1407,13 @@ fn delim_run_can_open(s: &str, suffix: &str, run_len: usize, ix: usize) -> bool 
         return true;
     }
     let delim = suffix.chars().next().unwrap();
-    if delim == '*' && !next_char.is_ascii_punctuation() {
+    if delim == '*' && !is_punctuation(next_char) {
         return true;
     }
 
     let prev_char = s[..ix].chars().rev().next().unwrap();
 
-    prev_char.is_whitespace() || prev_char.is_ascii_punctuation()
+    prev_char.is_whitespace() || is_punctuation(prev_char)
 }
 
 /// Determines whether the delimiter run starting at given index is
@@ -1433,11 +1433,11 @@ fn delim_run_can_close(s: &str, suffix: &str, run_len: usize, ix: usize) -> bool
         return true;
     };
     let delim = suffix.chars().next().unwrap();
-    if delim == '*' && !prev_char.is_ascii_punctuation() {
+    if delim == '*' && !is_punctuation(prev_char) {
         return true;
     }
 
-    next_char.is_whitespace() || next_char.is_ascii_punctuation()
+    next_char.is_whitespace() || is_punctuation(next_char)
 }
 
 /// Checks whether we should break a paragraph on the given input.

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -96,3 +96,24 @@ include!("normalize_html.rs.inc");
 
         assert_eq!(normalize_html(&expected), normalize_html(&s));
     }
+
+    #[test]
+    fn regression_test_4() {
+        let original = r##"foo§__(bar)__
+"##;
+        let expected = r##"<p>foo§<strong>(bar)</strong></p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(Options::ENABLE_TABLES);
+        opts.insert(Options::ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(normalize_html(&expected), normalize_html(&s));
+    }


### PR DESCRIPTION
Fixes incompatibility with CommonMark spec, adds a regression test and fixes compiler warnings in process!