### PR TITLE
Use memchr crate to speed up scanning specific chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ doc = false
 [dependencies]
 bitflags = "1.0"
 unicase = "2.2.0"
+memchr = "2.2"
 getopts = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -23,6 +23,7 @@
 use std::collections::HashMap;
 
 use unicase::UniCase;
+use memchr::memchr;
 
 use crate::strings::{CowStr, InlineStr};
 use crate::scanners::*;
@@ -1581,9 +1582,26 @@ impl<'t, 'a> InlineScanner<'t, 'a> {
         self.scan_if(|scanned| scanned == c)
     }
 
-    // Note(optimization): could use memchr
     fn scan_upto(&mut self, c: u8) -> usize {
-        self.scan_while(|scanned| scanned != c)
+        let upperbound = if let Some(parent_ix) = self.tree.peek_up() {
+           self.tree[parent_ix].item.end 
+        } else {
+            self.text.len()
+        };
+        let bytes = &self.text.as_bytes()[self.ix..upperbound];
+        let memchr_res = memchr(c, bytes);
+        self.ix = memchr_res.map(|ix| self.ix + ix).unwrap_or(bytes.len());
+
+        // jump to right node
+        while let TreePointer::Valid(cur_ix) = self.cur {
+            if self.ix <= self.tree[cur_ix].item.end {
+                break;
+            } else {
+                self.cur = self.tree[cur_ix].next;
+            }
+        }
+
+        memchr_res.unwrap_or(bytes.len())
     }
 
     fn scan_if<F>(&mut self, mut f: F) -> bool

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -28,6 +28,8 @@ use crate::parse::Alignment;
 use crate::strings::CowStr;
 pub use crate::puncttable::{is_ascii_punctuation, is_punctuation};
 
+use memchr::memchr;
+
 // sorted for binary search
 const HTML_TAGS: [&'static str; 62] = ["address", "article", "aside", "base",
     "basefont", "blockquote", "body", "caption", "center", "col", "colgroup",
@@ -302,10 +304,7 @@ pub fn scan_blank_line(text: &str) -> Option<usize> {
 }
 
 pub fn scan_nextline(s: &str) -> usize {
-    match s.as_bytes().iter().position(|&c| c == b'\n') {
-        Some(x) => x + 1,
-        None => s.len()
-    }
+    memchr(b'\n', s.as_bytes()).map(|x| x + 1).unwrap_or(s.len())
 }
 
 // return: end byte for closing code fence, or None


### PR DESCRIPTION
Used `memchr` to speed up two routines that scan for a single character and ran 11 benchmark loops on the crdt.md file.

desc  | memchr runtime (ns) | baseline runtime (ns) | thruput quotient
-- | --: | --: | --:
run 0  | 580920 | 590566 |  101.66%
run 1  | 565808 | 586689 |  103.69%
run 2  | 589241 | 591851 |  100.44%
run 3  | 568167 | 592621 |  104.30%
run 4  | 565312 | 590191 |  104.40%
run 5  | 584687 | 597149 |  102.13%
run 6  | 573395 | 590270 |  102.94%
run 7  | 566380 | 588118 |  103.84%
run 8  | 579796 | 595598 |  102.73%
run 9  | 569794 | 594025 |  104.25%
run 10  | 572270 | 589146 |  102.95%
**avg** | **631577** | **650622.4** | **103.02%**
**min** | **565312** | **586689** | **103.78%**
