### PR TITLE
Add azure pipelines config stub

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,12 @@
+pool:
+  vmImage: 'ubuntu-16.04'
+
+steps:
+  - script: |
+      curl https://sh.rustup.rs -sSf | sh -s -- -y
+      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+    displayName: Install rust
+  - script: cargo build --all
+    displayName: Cargo build
+  - script: cargo test --all
+    displayName: Cargo test


### PR DESCRIPTION
This adds configuration for **basic** azure pipelines CI. Just runs the tests using Rust stable on ubuntu 16.04.

The configuration seems to be a prerequisite for actually enabling the pipelines. This config works well on my fork.