### PR TITLE
Update scanner::scan_hrule to return Option<usize>

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -369,8 +369,7 @@ impl<'a> FirstPass<'a> {
         // Advance `ix` after HTML blocks have been scanned
         let ix = start_ix + line_start.bytes_scanned();
 
-        let n = scan_hrule(&self.text[ix..]);
-        if n > 0 {
+        if let Some(n) = scan_hrule(&self.text[ix..]) {
             return self.parse_hrule(n, ix);
         }
 
@@ -1467,7 +1466,7 @@ fn delim_run_can_close(s: &str, suffix: &str, run_len: usize, ix: usize) -> bool
 /// whether to break on a list requires additional context.
 fn scan_paragraph_interrupt(s: &str) -> bool {
     scan_eol(s).1 ||
-    scan_hrule(s) > 0 ||
+    scan_hrule(s).is_some() ||
     scan_atx_heading(s).is_some() ||
     scan_code_fence(s).0 > 0 ||
     get_html_end_tag(s).is_some() ||


### PR DESCRIPTION
This PR updates the `scanner::scan_hrule` fn to return an `Option<usize>`
rather than a `usize`, where `None` was represented by returning `0`.