### PR TITLE
Implement Clone for parse::Parser

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -133,14 +133,14 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct Item<'a> {
     start: usize,
     end: usize,
     body: ItemBody<'a>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 enum ItemBody<'a> {
     Paragraph,
     Text,
@@ -2229,11 +2229,13 @@ enum LinkStackTy {
     Disabled,
 }
 
+#[derive(Clone)]
 struct LinkDef<'a> {
     dest: CowStr<'a>,
     title: Option<CowStr<'a>>,
 }
 
+#[derive(Clone)]
 pub struct Parser<'a> {
     text: &'a str,
     tree: Tree<Item<'a>>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -39,7 +39,7 @@ impl TreeIndex {
 
 impl Add<usize> for TreeIndex {
     type Output = TreeIndex;
- 
+
     fn add(self, rhs: usize) -> Self {
         let inner = self.0.get() + rhs;
         TreeIndex::new(inner)
@@ -55,7 +55,7 @@ impl Sub<usize> for TreeIndex {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node<T> {
     pub child: TreePointer,
     pub next: TreePointer,
@@ -63,6 +63,7 @@ pub struct Node<T> {
 }
 
 /// A tree abstraction, intended for fast building as a preorder traversal.
+#[derive(Clone)]
 pub struct Tree<T> {
     nodes: Vec<Node<T>>,
     spine: Vec<TreeIndex>, // indices of nodes on path to current node


### PR DESCRIPTION
This PR implements `Clone` for `parse::Parser`

Resolves #169 