### PR TITLE
Update scanner::scan_blockquote_start to return Option<usize>

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1470,7 +1470,7 @@ fn scan_paragraph_interrupt(s: &str) -> bool {
     scan_atx_heading(s).is_some() ||
     scan_code_fence(s).0 > 0 ||
     get_html_end_tag(s).is_some() ||
-    scan_blockquote_start(s) > 0 ||
+    scan_blockquote_start(s).is_some() ||
     is_html_tag(scan_html_block_tag(s).1)
 }
 

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -519,14 +519,11 @@ pub fn scan_code_fence(data: &str) -> (usize, u8) {
     (0, 0)
 }
 
-// TODO: change return type to Option.
-pub fn scan_blockquote_start(data: &str) -> usize {
-    if data.starts_with('>') {
-        let n = 1;
-        n + scan_ch(&data[n..], b' ')
-    } else {
-        0
+pub fn scan_blockquote_start(data: &str) -> Option<usize> {
+    if !data.starts_with('>') {
+        return None;
     }
+    Some(scan_ch(&data[1..], b' ') + 1)
 }
 
 /// This already assumes the list item has been scanned.


### PR DESCRIPTION
This PR updates the `scanner::scan_hrule` fn to return an `Option<usize>`