### PR TITLE
Update scanner::scan_code_fence to return Option

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -383,11 +383,9 @@ impl<'a> FirstPass<'a> {
             return ix + bytecount;
         }
 
-        let (n, fence_ch) = scan_code_fence(&self.text[ix..]);
-        if n > 0 {
+        if let Some((n, fence_ch)) = scan_code_fence(&self.text[ix..]) {
             return self.parse_fenced_code_block(ix, indent, fence_ch, n);
         }
-        
         self.parse_paragraph(ix)
     }
 
@@ -1468,7 +1466,7 @@ fn scan_paragraph_interrupt(s: &str) -> bool {
     scan_eol(s).1 ||
     scan_hrule(s).is_some() ||
     scan_atx_heading(s).is_some() ||
-    scan_code_fence(s).0 > 0 ||
+    scan_code_fence(s).is_some() ||
     get_html_end_tag(s).is_some() ||
     scan_blockquote_start(s) > 0 ||
     is_html_tag(scan_html_block_tag(s).1)

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -498,25 +498,26 @@ pub fn scan_table_head(data: &str) -> (usize, Vec<Alignment>) {
     (i, cols)
 }
 
-// TODO: change return type to Option.
-// returns: number of bytes scanned, char
-pub fn scan_code_fence(data: &str) -> (usize, u8) {
+/// Scan code fence.
+///
+/// Returns number of bytes scanned and the char that is repeated to make the code fence.
+pub fn scan_code_fence(data: &str) -> Option<(usize, u8)> {
     if data.is_empty() {
-        return (0, 0);
+        return None;
     }
     let c = data.as_bytes()[0];
-    if !(c == b'`' || c == b'~') { return (0, 0); }
+    if !(c == b'`' || c == b'~') { return None; }
     let i = 1 + scan_ch_repeat(&data[1 ..], c);
     if i >= 3 {
         if c == b'`' {
             let next_line = i + scan_nextline(&data[i..]);
             if data[i..next_line].find('`').is_some() {
-                return (0, 0);
+                return None;
             }
         }
-        return (i, c);
+        return Some((i, c));
     }
-    (0, 0)
+    None
 }
 
 // TODO: change return type to Option.


### PR DESCRIPTION
This PR updates the `scanner::scan_code_fence` fn to return an
`Option<(usize, u8)>` rather than a `(usize, u8)`