### PR TITLE
Write html output to Vec before writing to output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,8 +262,9 @@ pub fn main() {
         } else {
             let p = Parser::new_ext(&input, opts);
             let stdio = io::stdout();
-            let buffer = std::io::BufWriter::new(stdio.lock());
-            html::write_html(buffer, p).unwrap();
+            let mut buffer = Vec::with_capacity(input.len());
+            html::write_html(&mut buffer, p).unwrap();
+            std::io::BufWriter::new(stdio.lock()).write_all(&buffer).unwrap();
         }
     }
 }


### PR DESCRIPTION
This provides a 5% speedup when tested on 10_000 × crdt.md. Unsure if it's worth it considering the highly increased RAM usage.