### PR TITLE
Use 1MB stdout BufWriter buffer size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ pub fn main() {
         } else {
             let p = Parser::new_ext(&input, opts);
             let stdio = io::stdout();
-            let buffer = std::io::BufWriter::new(stdio.lock());
+            let buffer = std::io::BufWriter::with_capacity(1*1024*1024, stdio.lock());
             html::write_html(buffer, p).unwrap();
         }
     }


### PR DESCRIPTION
This should give 4-5% performance improvement.

Copied from https://github.com/raphlinus/pulldown-cmark/pull/250#issuecomment-477066169:

Tested on 10000×crdt.md.  
`DEFAULT_BUF_SIZE` (`BufWriter::new()`): 8KB (<https://github.com/rust-lang/rust/blob/190feb65290d39d7ab6d44e994bd99188d339f16/src/libstd/sys_common/io.rs#L1>)

Capacity | Time 1 | Time 2 | Time 3 | Avg | Time rel. to Default
--- | :-- | :-- | :-- | :-- | --:
8KB | 5.941 | 5.906 | 5.930 | 5.926 | 100.0%
128KB | 5.889 | 5.836 | 5.745 | 5.824 | 98.3%
1MB | 5.703 | 5.664 | 5.699 | 5.689 | 96.0%
2MB | 5.721 | 5.792 | 5.727 | 5.747 | 97.0%
4MB | 5.740 | 5.715 | 5.737 | 5.726 | 96.7%
8MB | 5.727 | 5.754 | 5.767 | 5.749 | 97.0%

I can't really interpret this data, and I think considering the minimal performance improvements, more samples should be used. These tests are on a rather old machine (i7-4790, Samsung SSD 860 EVO). On my other machine (i7-6700K, Samsung 960 PRO NVMe M.2 SSD) I had 95% with 1MB and 92% at 8MB. With 128MB buffer I was back down to 100% compared to the default 8KB.

I guess it's safe to say that using 1MB is the safest bet and should give 4-5% performance improvement (which interestingly is the same as #250 , which buffers everything).