### PR TITLE
Guard against pathological hrule scans

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -58,4 +58,40 @@ mod to_html {
 
         b.iter(|| render_html(&buf, Options::empty()));
     }
+
+    #[bench]
+    fn more_pathological_codeblocks(b: &mut test::Bencher) {
+        let input = std::iter::repeat("\\``").take(1000).collect::<String>();
+
+        b.iter(|| render_html(&input, Options::empty()));
+    }
+
+    #[bench]
+    fn pathological_hrules(b: &mut test::Bencher) {
+        let mut input = std::iter::repeat("* ").take(2000).collect::<String>();
+        input.push('a');
+
+        b.iter(|| render_html(&input, Options::empty()));
+    }
+
+    #[bench]
+    fn advanced_pathological_codeblocks(b: &mut test::Bencher) {
+        // Note that `buf` grows quadratically with number of
+        // iterations. The point here is that the render time shouldn't
+        // grow faster than that.
+        let size = 120;
+        let mut buf = String::new();
+        for i in 1..size {
+            for _ in 0..i {
+                buf.push('`');
+            }
+            buf.push(' ');
+        }
+        for _ in 1..(size * size) {
+            buf.push_str("*a* ");
+        }
+        eprintln!("str size: {}", buf.len());
+
+        b.iter(|| render_html(&buf, Options::empty()));
+    }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -376,7 +376,7 @@ impl<'a> FirstPass<'a> {
         // Advance `ix` after HTML blocks have been scanned
         let ix = start_ix + line_start.bytes_scanned();
 
-        if let Some(n) = scan_hrule(&self.text[ix..]) {
+        if let Ok(n) = scan_hrule(&self.text[ix..]) {
             return self.parse_hrule(n, ix);
         }
 
@@ -1457,7 +1457,7 @@ fn delim_run_can_close(s: &str, suffix: &str, run_len: usize, ix: usize) -> bool
 /// whether to break on a list requires additional context.
 fn scan_paragraph_interrupt(s: &str) -> bool {
     scan_eol(s).is_some() ||
-    scan_hrule(s).is_some() ||
+    scan_hrule(s).is_ok() ||
     scan_atx_heading(s).is_some() ||
     scan_code_fence(s).is_some() ||
     get_html_end_tag(s).is_some() ||


### PR DESCRIPTION
Fixes https://github.com/raphlinus/pulldown-cmark/issues/249 using the same approach the other parsers took: remember the offset that killed the hrule and don't scan for hrules before that offset again.