### PR TITLE
Guard against pathological link titles

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -75,6 +75,13 @@ mod to_html {
     }
 
     #[bench]
+    fn pathological_link_titles(b: &mut test::Bencher) {
+        let input = std::iter::repeat("[ (](").take(2000).collect::<String>();
+
+        b.iter(|| render_html(&input, Options::empty()));
+    }
+
+    #[bench]
     fn advanced_pathological_codeblocks(b: &mut test::Bencher) {
         // Note that `buf` grows quadratically with number of
         // iterations. The point here is that the render time shouldn't

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2006,25 +2006,22 @@ fn scan_link_title<'t, 'a>(scanner: &mut InlineScanner<'t, 'a>) -> Option<CowStr
     if !(open == '\'' || open == '\"' || open == '(') {
         return None;
     }
+    let close = if open == '(' { ')' } else { open };
     let underlying = &scanner.text[scanner.ix..];
     let mut title = String::new();
     let mut still_borrowed = true;
     let mut bytecount = 0;
-    let mut nest = 0;
     while let Some(mut c) = scanner.next_char() {
-        if c == open {
-            if open == '(' {
-                nest += 1;
+        if c == close {
+            let cow = if still_borrowed {
+                underlying[..bytecount].into()
             } else {
-                return Some(if still_borrowed { underlying[..bytecount].into() } else { title.into() });
-            }
+                title.into()
+            };
+            return Some(cow);
         }
-        if open == '(' && c == ')' {
-            if nest == 0 {
-                return Some(if still_borrowed { underlying[..bytecount].into() } else { title.into() });
-            } else {
-                nest -= 1;
-            }
+        if c == open {
+            return None;
         }
         if c == '\\' {
             let c_next = scanner.next_char()?;


### PR DESCRIPTION
Fixes https://github.com/raphlinus/pulldown-cmark/issues/251.

This change is allowed by [this recent change in the spec](https://github.com/commonmark/CommonMark/commit/9dc64f19002ed30a635ada88c06dece7cc969547).