### PR TITLE
Remove html renderer unsafety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ readme = "README.md"
 
 build = "build.rs"
 
-[profile.release]
-debug = true
-
 [[bin]]
 name = "pulldown-cmark"
 required-features = ["getopts"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 
 build = "build.rs"
 
+[profile.release]
+debug = true
+
 [[bin]]
 name = "pulldown-cmark"
 required-features = ["getopts"]

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -162,12 +162,12 @@ mod simd {
             unsafe {
                 foreach_special_simd(bytes, 0, |i| {
                     let replacement = super::HTML_ESCAPES[super::HTML_ESCAPE_TABLE[bytes[i] as usize] as usize];
-                    w.write_all(&bytes[mark..i])?;
+                    w.write_str(&s[mark..i])?;
                     mark = i + 1; // all escaped characters are ASCII
-                    w.write_all(replacement.as_bytes())
+                    w.write_str(replacement)
                 })?;
             }
-            w.write_all(&bytes[mark..])
+            w.write_str(&s[mark..])
         } else {
             super::escape_html_scalar(w, s)
         }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -23,6 +23,8 @@
 use std::io::{self, Write};
 use std::str::from_utf8;
 
+use crate::html::StrWrite;
+
 static HREF_SAFE: [u8; 128] = [
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -35,12 +37,12 @@ static HREF_SAFE: [u8; 128] = [
     ];
 
 static HEX_CHARS: &'static [u8] = b"0123456789ABCDEF";
-static AMP_ESCAPE: &'static [u8] = b"&amp;";
-static SLASH_ESCAPE: &'static [u8] = b"&#x27;";
+static AMP_ESCAPE: &'static str = "&amp;";
+static SLASH_ESCAPE: &'static str = "&#x27;";
 
 pub(crate) fn escape_href<W>(mut w: W, s: &str) -> io::Result<()>
 where
-    W: Write,
+    W: StrWrite,
 {
     let bytes = s.as_bytes();
     let mut mark = 0;
@@ -51,28 +53,28 @@ where
 
             // write partial substring up to mark
             if mark < i {
-                w.write_all(&bytes[mark..i])?;
+                w.write_str(&s[mark..i])?;
             }
             match c {
                 b'&' => {
-                    w.write_all(AMP_ESCAPE)?;
+                    w.write_str(AMP_ESCAPE)?;
                 }
                 b'\'' => {
-                    w.write_all(SLASH_ESCAPE)?;
+                    w.write_str(SLASH_ESCAPE)?;
                 }
                 _ => {
                     let mut buf = [0u8; 3];
                     buf[0] = b'%';
                     buf[1] = HEX_CHARS[((c as usize) >> 4) & 0xF];
                     buf[2] = HEX_CHARS[(c as usize) & 0xF];
-                    let escaped = from_utf8(&buf).unwrap().as_bytes();
-                    w.write_all(escaped)?;
+                    let escaped = from_utf8(&buf).unwrap();
+                    w.write_str(escaped)?;
                 }
             }
             mark = i + 1; // all escaped characters are ASCII
         }
     }
-    w.write_all(&bytes[mark..])
+    w.write_str(&s[mark..])
 }
 
 static HTML_ESCAPE_TABLE: [u8; 256] = [
@@ -104,14 +106,14 @@ static HTML_ESCAPES: [&'static str; 5] = [
 
 /// Writes the given string to the Write sink, replacing special HTML bytes
 /// (<, >, &, ") by escape sequences.
-pub(crate) fn escape_html<W: Write>(w: W, s: &str) -> io::Result<()> {
+pub(crate) fn escape_html<W: StrWrite>(w: W, s: &str) -> io::Result<()> {
     #[cfg(all(target_arch = "x86_64", feature="simd"))]
     { simd::escape_html(w, s) }
     #[cfg(not(all(target_arch = "x86_64", feature="simd")))]
     { escape_html_scalar(w, s) }
 }
 
-fn escape_html_scalar<W: Write>(mut w: W, s: &str) -> io::Result<()> {
+fn escape_html_scalar<W: StrWrite>(mut w: W, s: &str) -> io::Result<()> {
     let bytes = s.as_bytes();
     let mut mark = 0;
     let mut i = 0;
@@ -129,13 +131,13 @@ fn escape_html_scalar<W: Write>(mut w: W, s: &str) -> io::Result<()> {
         let escape = HTML_ESCAPE_TABLE[c as usize];
         if escape != 0 {
             let escape_seq = HTML_ESCAPES[escape as usize];
-            w.write_all(&bytes[mark..i])?;
-            w.write_all(escape_seq.as_bytes())?;
+            w.write_str(&s[mark..i])?;
+            w.write_str(escape_seq)?;
             mark = i + 1; // all escaped characters are ASCII
         }
         i += 1;
     }
-    w.write_all(&bytes[mark..])
+    w.write_str(&s[mark..])
 }
 
 #[cfg(all(target_arch = "x86_64", feature="simd"))]
@@ -143,10 +145,11 @@ mod simd {
     use std::arch::x86_64::*;
     use std::io::{self, Write};
     use std::mem::size_of;
+    use crate::html::StrWrite;
 
     const VECTOR_SIZE: usize = size_of::<__m128i>();
 
-    pub(crate) fn escape_html<W: Write>(mut w: W, s: &str) -> io::Result<()> {
+    pub(crate) fn escape_html<W: StrWrite>(mut w: W, s: &str) -> io::Result<()> {
         // The SIMD accelerated code uses the PSHUFB instruction, which is part
         // of the SSSE3 instruction set. Further, we can only use this code if
         // the buffer is at least one VECTOR_SIZE in length to prevent reading 
@@ -182,6 +185,7 @@ mod simd {
     }
 
     #[target_feature(enable = "ssse3")]
+    #[inline]
     /// Computes a byte mask at given offset in the byte buffer. Its first 16 (least significant)
     /// bits correspond to whether there is an HTML special byte (&, <, ", >) at the 16 bytes
     /// `bytes[offset..]`. For example, the mask `(1 << 3)` states that there is an HTML byte

--- a/src/html.rs
+++ b/src/html.rs
@@ -34,7 +34,6 @@ enum TableState {
     Body,
 }
 
-// FIXME: find better name
 /// Wrapper for String for which we can implement `StrWrite`.
 /// We can't implement it for `String` directly as it could theoretically
 /// conflict with the blanket implementation if `std::io::Write` was
@@ -43,7 +42,7 @@ struct StringWrap<'w>(&'w mut String);
 
 struct StrWriteMutRef<'w, W>(&'w mut W);
 
-// TODO: expose this
+// TODO: expose this?
 pub trait StrWrite {
     fn write_str(&mut self, s: &str) -> io::Result<()>;
 
@@ -174,12 +173,11 @@ where
                     write!(&mut self.writer, "{}", number)?;
                     self.write("</a></sup>", false)?;
                 }
-                TaskListMarker(is_checked) => {
-                    self.write("<input disabled=\"\" type=\"checkbox\"", false)?;
-                    if is_checked {
-                        self.write(" checked=\"\"", false)?;
-                    }
-                    self.write("/>", true)?;
+                TaskListMarker(true) => {
+                    self.write("<input disabled=\"\" type=\"checkbox\" checked=\"\"/>", true)?;
+                }
+                TaskListMarker(false) => {
+                    self.write("<input disabled=\"\" type=\"checkbox\"/>", true)?;
                 }
             }
         }


### PR DESCRIPTION
Addresses https://github.com/raphlinus/pulldown-cmark/issues/266 by introducing a `StrWrite` trait that enables writing string slices. It has a blanket implementation for types implementing `std::io::Write`, so we should remain fully backward compatible.

This blanket implementation does force some trickery since `std::io::Write` is an external trait. Rust won't let us implement `StrWrite` for types that are not defined in the crate itself since it can't know they won't implement `Write` in the future and introduce a conflict. Hence we need wrapper types, one for `String` and one for `&'_ mut W where W: Write`. This solution isn't particularly elegant, so I'm very open to alternatives!

Performance is within 1% of master.