### PR TITLE
Some fuzzer tweaks

### DIFF
--- a/fuzzer/README.md
+++ b/fuzzer/README.md
@@ -1,12 +1,12 @@
-# Fuzzer for detecting non-linear growth in pulldown-cmark
+# Fuzzer for detecting superlinear growth in pulldown-cmark
 
-This fuzzer tries to find non-linear growth in pulldown-cmark wrt. input length.
+This fuzzer tries to find superlinear growth in pulldown-cmark wrt. input length.
 The general approach is to parse the source code of pulldown-cmark, extract
 literals which are used in branching code (if-conditions, match patterns,
 match guards, …) and add some manually.
 Random combinations of those literals are generated.
 The pulldown-cmark parser is then timed against repetitions of different length
-of those literals to identify non-linear parsing behaviour.
+of those literals to identify superlinear parsing behaviour.
 
 ## Running
 
@@ -14,11 +14,11 @@ Running the fuzzer can be done by executing the `./run` script.
 The constants in `main.rs` should be tweaked for the system the fuzzer is
 executed on, as some of them are system dependent.
 The number of threads can be changed in the `main()` function.
-It defaults to using ¾ of available threads.
+It defaults to using 80% of the number of system threads, rounding up.
 
 The fuzzer will run until manually stopped.
 All output will be written to the file `output` and will most likely contain
-lots of false positives (currently around 93% false positive rate).
+many false positives.
 Therefore, after fuzzing has been stopped, the `./retest-output` script should
 be executed.
 It'll retest found patterns several times to remove as many false positives as

--- a/fuzzer/src/literals.rs
+++ b/fuzzer/src/literals.rs
@@ -33,7 +33,6 @@ pub fn get() -> Vec<Vec<u8>> {
         if skipped_files.contains(&file.path()) {
             continue;
         }
-        println!("parsing {}", file.path().display());
         literal_parser.extract_literals_from_file(file.path());
     }
 


### PR DESCRIPTION
This PR makes a few small changes:
 - do throughput reporting on main thread
 - reduce size of inputs for increased throughput
 - don't throw away outliers, but retest more often to confirm problematic patterns
 - round up when computing number of threads or else it won't run on single core systems at all :sweat_smile:

Throughput is significantly higher with fewer false positives on my machine. 

Could you review @oberien?