### PR TITLE
Allow for more flexible fuzzer patterns

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -14,57 +14,6 @@ mod to_html {
     }
 
     #[bench]
-    fn pathological_links(b: &mut test::Bencher) {
-        let input = "[a](<".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_links2(b: &mut test::Bencher) {
-        let input = "[[]()".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_emphasis1(b: &mut test::Bencher) {
-        let input = "a***".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_emphasis2(b: &mut test::Bencher) {
-        let input = "a***_b__".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_emphasis3(b: &mut test::Bencher) {
-        let input = "[*_a".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_emphasis4(b: &mut test::Bencher) {
-        let input = "*~~\u{a0}".repeat(1000);
-        let mut opts = Options::empty();
-        opts.insert(Options::ENABLE_STRIKETHROUGH);
-
-        b.iter(|| render_html(&input, opts));
-    }
-
-    #[bench]
-    fn pathological_strikethrough(b: &mut test::Bencher) {
-        let input = "a***b~~".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
     fn pathological_codeblocks1(b: &mut test::Bencher) {
         // Note that `buf` grows quadratically with number of
         // iterations. The point here is that the render time shouldn't
@@ -78,36 +27,6 @@ mod to_html {
         }
 
         b.iter(|| render_html(&buf, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_codeblocks2(b: &mut test::Bencher) {
-        let input = "\\``".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_codeblocks3(b: &mut test::Bencher) {
-        let mut input = "`a`".repeat(1000);
-        input.push('`');
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_hrules(b: &mut test::Bencher) {
-        let mut input = "* ".repeat(1000);
-        input.push('a');
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_link_titles(b: &mut test::Bencher) {
-        let input = "[ (](".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
     }
 
     #[bench]
@@ -126,26 +45,5 @@ mod to_html {
         }
 
         b.iter(|| render_html(&buf, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_cdata(b: &mut test::Bencher) {
-        let input = "a <![CDATA[ ".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_html_processing(b: &mut test::Bencher) {
-        let input = "a <? ".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
-    }
-
-    #[bench]
-    fn pathological_html_defs(b: &mut test::Bencher) {
-        let input = "a <!A ".repeat(1000);
-
-        b.iter(|| render_html(&input, Options::empty()));
     }
 }

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -25,7 +25,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ dependencies = [
  "ndarray-stats 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "pulldown-cmark 0.5.2",
+ "pulldown-cmark 0.5.3",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -407,7 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -57,7 +57,6 @@ dependencies = [
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray-stats 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.5.3",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/fuzzer/Cargo.lock
+++ b/fuzzer/Cargo.lock
@@ -60,6 +60,8 @@ dependencies = [
  "pulldown-cmark 0.5.3",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -92,6 +94,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -327,11 +334,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "same-file"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -417,6 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
 "checksum matrixmultiply 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "dcad67dcec2d58ff56f6292582377e6921afdf3bfbd533e26fb8900ae575e002"
@@ -443,7 +484,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03b418169fb9c46533f326efd6eed2576699c44ca92d3052a066214a8d828929"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
+"checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
+"checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
+"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -16,6 +16,8 @@ rand_xoshiro = "0.1.0"
 num_cpus = "1.10.0"
 crossbeam-utils = "0.6.5"
 libc = "0.2.54"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [profile.release]
 debug = true

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -9,7 +9,6 @@ syn = { version = "0.15.33", features = ["full"] }
 itertools = "0.8.0"
 walkdir = "2.2.7"
 pulldown-cmark = { path = ".." }
-proc-macro2 = "0.4.29"
 ndarray = "0.12.1"
 ndarray-stats = "0.2.0"
 rand = "0.6.5"

--- a/fuzzer/retest-output
+++ b/fuzzer/retest-output
@@ -8,7 +8,7 @@ UTF8PATTERN="Couldn't convert pattern to UTF-8. Err: "
 JOINPATTERN="Joined thread: "
 TIMEOUTPATTERN="Thread timeout triggered (thread took too long) for Pattern: "
 # pattern to extract actual findings
-FINDPATTERN='^pattern: "'
+FINDPATTERN='^pattern: Pattern"'
 # output file of this program
 OUTFILE="output-retested"
 # temporary output file while performing a retesting run

--- a/fuzzer/retest-output
+++ b/fuzzer/retest-output
@@ -8,7 +8,7 @@ UTF8PATTERN="Couldn't convert pattern to UTF-8. Err: "
 JOINPATTERN="Joined thread: "
 TIMEOUTPATTERN="Thread timeout triggered (thread took too long) for Pattern: "
 # pattern to extract actual findings
-FINDPATTERN='^pattern: Pattern"'
+FINDPATTERN='^pattern: '
 # output file of this program
 OUTFILE="output-retested"
 # temporary output file while performing a retesting run
@@ -25,7 +25,7 @@ retestround() {
   grep "$JOINPATTERN" "$OUTFILE2" >> "$OUTFILE" && :
   grep "$TIMEOUTPATTERN" "$OUTFILE2" >> "$OUTFILE" && :
   cargo rustc --release -- -C target-cpu=native > /dev/null 2>&1
-  grep "$FINDPATTERN" < "$OUTFILE2" | sed 's/pattern: "\(.*\)"/\1/' | RUST_BACKTRACE=1 ./target/release/fuzzer --retest >> "$OUTFILE" 2>&1
+  grep "$FINDPATTERN" < "$OUTFILE2" | sed 's/pattern: \({.*}\)/\1/' | RUST_BACKTRACE=1 ./target/release/fuzzer --retest >> "$OUTFILE" 2>&1
   rm "$OUTFILE2"
 }
 

--- a/fuzzer/retest-output
+++ b/fuzzer/retest-output
@@ -25,7 +25,7 @@ retestround() {
   grep "$JOINPATTERN" "$OUTFILE2" >> "$OUTFILE" && :
   grep "$TIMEOUTPATTERN" "$OUTFILE2" >> "$OUTFILE" && :
   cargo rustc --release -- -C target-cpu=native > /dev/null 2>&1
-  grep "$FINDPATTERN" < "$OUTFILE2" | sed 's/pattern: \({.*}\)/\1/' | RUST_BACKTRACE=1 ./target/release/fuzzer --retest >> "$OUTFILE" 2>&1
+  grep "$FINDPATTERN" < "$OUTFILE2" | sed 's/pattern: \(.*\)/\1/' | RUST_BACKTRACE=1 ./target/release/fuzzer --retest >> "$OUTFILE" 2>&1
   rm "$OUTFILE2"
 }
 
@@ -41,8 +41,8 @@ for i in `seq 3`; do
 
   finds_before=$finds_after
   retestround
-  finds_after=$(grep "$FINDPATTERN" "$OUTFILE" | wc -l)
 
+  finds_after=$(grep "$FINDPATTERN" "$OUTFILE" | wc -l)
   false_positives_this_round=$(($finds_before - $finds_after))
   false_positives=$(($false_positives + $false_positives_this_round))
 

--- a/fuzzer/src/clock.rs
+++ b/fuzzer/src/clock.rs
@@ -1,7 +1,7 @@
-use std::time::Duration;
-use std::mem;
 use std::io::Error;
 use std::marker::PhantomData;
+use std::mem;
+use std::time::Duration;
 
 #[allow(dead_code)]
 pub enum Monotonic {}

--- a/fuzzer/src/literals.rs
+++ b/fuzzer/src/literals.rs
@@ -350,12 +350,12 @@ impl LiteralParser {
             // handling lo is enough as we can trigger that pattern with the lo element already
             Pat::Range(pat) => self.extract_literals_from_expr(*pat.lo),
             Pat::Slice(pat) => {
-                for pat in pat
+                let pats_iter = pat
                     .front
                     .into_iter()
                     .chain(pat.middle.map(|pat| *pat))
-                    .chain(pat.back)
-                {
+                    .chain(pat.back);
+                for pat in pats_iter {
                     self.extract_literals_from_pat(pat);
                 }
             }

--- a/fuzzer/src/literals.rs
+++ b/fuzzer/src/literals.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
-use syn::{
-    Expr, ExprArray, ExprCall, ExprMethodCall, ExprTuple, ImplItem, Item, Lit, Pat, Stmt,
-};
+use syn::{Expr, ExprArray, ExprCall, ExprMethodCall, ExprTuple, ImplItem, Item, Lit, Pat, Stmt};
 use walkdir::WalkDir;
 
 /// Get all relevant literals from pulldown-cmark to generate fuzzing input from.

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -76,7 +76,7 @@ const SAMPLE_SIZE: usize = 5;
 /// Possible values: `scoring::{slope_stddev,pearson_correlation}`
 const SCORE_FUNCTION: fn(&[(f64, f64)]) -> (f64, bool) = scoring::slope_stddev;
 /// If slope_stddev is used, if the standard deviation is larger than this, it's assumed to be non-linear.
-const ACCEPTANCE_STDDEV: f64 = 30.0;
+const ACCEPTANCE_STDDEV: f64 = 0.6;
 /// If pearson_correlation is used, if the correlation coefficient is below this value,
 /// it's assumed to be non-linear.
 const ACCEPTANCE_CORRELATION: f64 = 0.995;
@@ -389,9 +389,9 @@ fn test_pattern(pattern: &Pattern, time_samples: &mut [(f64, f64)]) -> PatternRe
     let mut i = 0;
 
     while i < sample_count {
-        let n = sample_pattern(pattern, &mut buf, i + 1, sample_count); // FIXME: set actual values
+        let n = sample_pattern(pattern, &mut buf, i + 1, sample_count);
         let dur = time_needed(&buf);
-        time_samples[i] = (n as f64, dur.as_nanos() as f64);
+        time_samples[i] = ((i + 1) as f64, dur.as_nanos() as f64);
         if DEBUG_LEVEL >= 3 {
             println!("duration: {}", dur.as_nanos());
         }
@@ -402,7 +402,7 @@ fn test_pattern(pattern: &Pattern, time_samples: &mut [(f64, f64)]) -> PatternRe
         i += 1;
     }
 
-    let (score, non_linear) = SCORE_FUNCTION(&time_samples);
+    let (score, non_linear) = SCORE_FUNCTION(time_samples);
 
     if DEBUG_LEVEL >= 1 {
         println!("{:<30}{:?}", score, pattern);

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -443,8 +443,8 @@ fn sample_pattern(
 /// Returns the length of the tested substring and the time needed for parsing given string.
 fn time_needed(sample: &str) -> Duration {
     // perform actual time measurement
-    let parser = Parser::new_ext(sample, Options::all());
     let clock = Clock::<ThreadCpuTime>::now();
+    let parser = Parser::new_ext(sample, Options::all());
     parser.for_each(|evt| {
         black_box::black_box(evt);
     });

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -79,7 +79,7 @@ const SAMPLE_SIZE: usize = 5;
 /// Possible values: `scoring::{slope_stddev,pearson_correlation}`
 const SCORE_FUNCTION: fn(&[(f64, f64)]) -> (f64, bool) = scoring::slope_stddev;
 /// If slope_stddev is used, if the standard deviation is larger than this, it's assumed to be non-linear.
-const ACCEPTANCE_STDDEV: f64 = 0.6;
+const ACCEPTANCE_STDDEV: f64 = 300.0;
 /// If pearson_correlation is used, if the correlation coefficient is below this value,
 /// it's assumed to be non-linear.
 const ACCEPTANCE_CORRELATION: f64 = 0.995;
@@ -406,11 +406,12 @@ fn test_pattern(pattern: &Pattern, time_samples: &mut [(f64, f64)]) -> PatternRe
     let mut i = 0;
     let mut buf = String::with_capacity(NUM_BYTES);
     buf.push_str(&pattern.prefix);
+    let mut n = 0;
 
     while i < sample_count {
-        let _n = sample_pattern(pattern, &mut buf, i + 1, sample_count);
+        n += sample_pattern(pattern, &mut buf, i + 1, sample_count);
         let dur = time_needed(&buf);
-        time_samples[i] = ((i + 1) as f64, dur.as_nanos() as f64);
+        time_samples[i] = (n as f64, dur.as_nanos() as f64);
 
         if DEBUG_LEVEL >= 3 {
             println!("duration: {}", dur.as_nanos());

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -145,7 +145,7 @@ fn main() {
     match arg.as_ref().map(|s| s.as_str()) {
         Some("--retest") => {
             for pattern in io::stdin().lock().lines().flatten() {
-                println!("retesting {:?}", &pattern);
+                println!("Retesting: {}", &pattern);
                 let pattern = serde_json::from_str(&pattern).expect("Couldn't deserialize pattern");
                 match test_catch_unwind(&pattern) {
                     Ok(res) => println!("score: {}", res.score()),

--- a/fuzzer/src/scoring.rs
+++ b/fuzzer/src/scoring.rs
@@ -40,12 +40,15 @@ pub fn slope_stddev(time_samples: &[(f64, f64)]) -> (f64, bool) {
     let mut slopes = [0f64; SAMPLE_SIZE * 2 * (SAMPLE_SIZE * 2 - 1) / 2];
     let mut i = 0;
 
+    let mean_time: f64 =
+        time_samples.iter().map(|tup| tup.1).sum::<f64>() / time_samples.len() as f64;
+
     for (point1, point2) in (0..time_samples.len()).tuple_combinations() {
         let (x1, y1) = time_samples[point1];
         let (x2, y2) = time_samples[point2];
         let dx = x2 - x1;
         let dy = y2 - y1;
-        let slope = dy / dx;
+        let slope = dy / dx / mean_time;
         slopes[i] = slope;
         i += 1;
     }

--- a/fuzzer/src/scoring.rs
+++ b/fuzzer/src/scoring.rs
@@ -1,9 +1,9 @@
 //! Functions detecting non-linear growth.
 
-use ndarray::{ArrayViewMut1, Array2};
-use ndarray_stats::CorrelationExt;
-use itertools::Itertools;
 use crate::SAMPLE_SIZE;
+use itertools::Itertools;
+use ndarray::{Array2, ArrayViewMut1};
+use ndarray_stats::CorrelationExt;
 
 /// Calculates the pearson_correlation of the passed `(len, time)`-array.
 #[allow(dead_code)]
@@ -37,7 +37,7 @@ pub fn pearson_correlation(time_samples: &[(f64, f64)]) -> (f64, bool) {
 /// If the function is not linear, the slopes will all be different, resulting in a higher stddev.
 #[allow(dead_code)]
 pub fn slope_stddev(time_samples: &[(f64, f64)]) -> (f64, bool) {
-    let mut slopes = [0f64; SAMPLE_SIZE*2 * (SAMPLE_SIZE*2 - 1) / 2];
+    let mut slopes = [0f64; SAMPLE_SIZE * 2 * (SAMPLE_SIZE * 2 - 1) / 2];
     let mut i = 0;
 
     for (point1, point2) in (0..time_samples.len()).tuple_combinations() {


### PR DESCRIPTION
This PR allows for more flexible patterns, repeating patterns with a variable but fixed prefix and postfix. As a result, almost all of the existing scaling regression tests could be moved into the fuzzer regression suite, which means that they'll be included in the CI pipeline.

@oberien: the fuzzer seems to panic immediately nowadays when left to fuzz, even on the master branch. I get the following trace:
```bash
marcusklaas@localhost ~/p/fuzzer> env RUST_BACKTRACE=1 cargo run --release
    Finished release [optimized + debuginfo] target(s) in 0.05s
     Running `target/release/fuzzer`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("expected `struct`")', src/libcore/result.rs:1051:5
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.29/src/backtrace/libunwind.rs:88
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.29/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:47
   3: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:36
   4: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:200
   5: std::panicking::default_hook
             at src/libstd/panicking.rs:214
   6: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:481
   7: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:384
   8: rust_begin_unwind
             at src/libstd/panicking.rs:311
   9: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  10: core::result::unwrap_failed
             at src/libcore/result.rs:1051
  11: core::result::Result<T,E>::unwrap
             at /rustc/bc2e84ca0939b73fcf1768209044432f6a15c2e5/src/libcore/result.rs:852
  12: <fuzzer::literals::LiteralParser::extract_literals_from_macro::Bitflags as syn::parse::Parse>::parse
             at src/literals.rs:218
  13: core::ops::function::FnOnce::call_once
             at /rustc/bc2e84ca0939b73fcf1768209044432f6a15c2e5/src/libcore/ops/function.rs:231
  14: <F as syn::parse::Parser>::parse2
             at /home/marcusklaas/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-0.15.34/src/parse.rs:1103
  15: syn::parse2
             at /home/marcusklaas/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-0.15.34/src/lib.rs:633
  16: fuzzer::literals::LiteralParser::extract_literals_from_macro
             at src/literals.rs:236
  17: fuzzer::literals::LiteralParser::extract_literals_from_item
             at src/literals.rs:134
  18: fuzzer::literals::LiteralParser::extract_literals_from_items
             at src/literals.rs:100
  19: fuzzer::literals::LiteralParser::extract_literals_from_file
             at src/literals.rs:95
  20: fuzzer::literals::get
             at src/literals.rs:47
  21: fuzzer::fuzz
             at src/main.rs:211
  22: fuzzer::main
             at src/main.rs:148
  23: std::rt::lang_start::{{closure}}
             at /rustc/bc2e84ca0939b73fcf1768209044432f6a15c2e5/src/libstd/rt.rs:64
  24: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:49
  25: std::panicking::try::do_call
             at src/libstd/panicking.rs:296
  26: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:82
  27: std::panicking::try
             at src/libstd/panicking.rs:275
  28: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  29: std::rt::lang_start_internal
             at src/libstd/rt.rs:48
  30: main
  31: __libc_start_main
  32: _start
```
I haven't dug too deep, but it seems related to the token parsing. Which would be strange, since neither the fuzzer's dependencies nor the project's structure has really changed. Do you happen to know what's going on here?