### PR TITLE
remove the getopts dependency from the lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,6 @@ tendril = "0.4"
 criterion = "0.2"
 
 [features]
-default = ["getopts"]
+default = []
 gen-tests = []
 simd = []


### PR DESCRIPTION
to avoid that crates that uses this lib needs to compile getopts