### PR TITLE
Remove `get_offset` method on `Parser`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ fn dry_run(text: &str, opts: Options) {
 }
 
 fn print_events(text: &str, opts: Options) {
-    for (range, event) in Parser::new_ext(text, opts).into_offset_iter() {
+    let parser = Parser::new_ext(text, opts).into_offset_iter();
+    for (event, range) in parser {
         println!("{:?}: {:?}", range, event);
     }
     println!("EOF");


### PR DESCRIPTION
It has been superseded by `OffsetIter`, which offers more complete and better defined functionality.

Addresses https://github.com/raphlinus/pulldown-cmark/issues/324. This PR goes for option 2, as source mapping seems to be a relatively niche feature.