### PR TITLE
Properly deal with refdefs inside blockquotes

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -660,3 +660,38 @@ ISSUE 298
 </blockquote>
 <p>[a b] [a > b]</p>
 ````````````````````````````````
+
+ISSUE 398
+
+```````````````````````````````` example
+[`cargo
+package`]
+
+[`cargo package`]: https://example.com
+.
+<p><a href="https://example.com"><code>cargo package</code></a></p>
+````````````````````````````````
+
+ISSUE 398
+
+```````````````````````````````` example
+> [`cargo
+> package`]
+
+[`cargo package`]: https://example.com
+.
+<blockquote>
+<p><a href="https://example.com"><code>cargo package</code></a></p>
+</blockquote>
+````````````````````````````````
+
+ISSUE 398
+
+```````````````````````````````` example
+> `cargo
+> package`
+.
+<blockquote>
+<p><code>cargo package</code></p>
+</blockquote>
+````````````````````````````````

--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -693,5 +693,18 @@ ISSUE 398
 .
 <blockquote>
 <p><code>cargo package</code></p>
+````````````````````````````````
+
+ISSUE 399
+
+```````````````````````````````` DISABLED example
+> Note: Though you should not rely on this, all pointers to <abbr
+> title="Dynamically Sized Types">DSTs</abbr> are currently twice the size of
+> the size of `usize` and have the same alignment.
+.
+<blockquote>
+<p>Note: Though you should not rely on this, all pointers to
+<abbr title="Dynamically Sized Types">DSTs</abbr> are currently twice the size of
+the size of <code>usize</code> and have the same alignment.</p>
 </blockquote>
 ````````````````````````````````

--- a/src/linklabel.rs
+++ b/src/linklabel.rs
@@ -34,13 +34,10 @@ pub type LinkLabel<'a> = UniCase<CowStr<'a>>;
 
 /// Assumes the opening bracket has already been scanned.
 /// Returns the number of bytes read (including closing bracket) and label on success.
-pub(crate) fn scan_link_label_rest<F>(
-    text: &str,
-    linebreak_handler: F,
-) -> Option<(usize, CowStr<'_>)>
-where
-    F: Fn(&[u8]) -> Option<usize>,
-{
+pub(crate) fn scan_link_label_rest<'t>(
+    text: &'t str,
+    linebreak_handler: &dyn Fn(&[u8]) -> Option<usize>,
+) -> Option<(usize, CowStr<'t>)> {
     let bytes = text.as_bytes();
     let mut ix = 0;
     let mut only_white_space = true;
@@ -122,13 +119,13 @@ mod test {
         let input = "«\t\tBlurry Eyes\t\t»][blurry_eyes]";
         let expected_output = "« Blurry Eyes »"; // regular spaces!
 
-        let (_bytes, normalized_label) = scan_link_label_rest(input, |_| None).unwrap();
+        let (_bytes, normalized_label) = scan_link_label_rest(input, &|_| None).unwrap();
         assert_eq!(expected_output, normalized_label.as_ref());
     }
 
     #[test]
     fn return_carriage_linefeed_ok() {
         let input = "hello\r\nworld\r\n]";
-        assert!(scan_link_label_rest(input, |_| Some(0)).is_some());
+        assert!(scan_link_label_rest(input, &|_| Some(0)).is_some());
     }
 }

--- a/src/linklabel.rs
+++ b/src/linklabel.rs
@@ -33,6 +33,10 @@ pub enum ReferenceLabel<'a> {
 pub type LinkLabel<'a> = UniCase<CowStr<'a>>;
 
 /// Assumes the opening bracket has already been scanned.
+/// The line break handler determines what happens when a linebreak
+/// is found. It is passed the bytes following the line break and
+/// either returns `Some(k)`, where `k` is the number of bytes to skip,
+/// or `None` to abort parsing the label.
 /// Returns the number of bytes read (including closing bracket) and label on success.
 pub(crate) fn scan_link_label_rest<'t>(
     text: &'t str,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1681,7 +1681,17 @@ fn scan_link_label<'text, 'tree>(
     }
     let linebreak_handler = |ix: usize| -> Option<usize> {
         if let TreePointer::Valid(node_ix) = scan_nodes_to_ix(tree, node, ix) {
-            Some(tree[node_ix].item.start - ix)
+            // FIXME: this doesn't work correctly when we break inside a code
+            // span, since it is replaced by a contiguous item.
+            //
+            // Maybe we should scan containers when ix is greater than node start?
+            // Like this:
+            //
+            // let mut line_start = LineStart::new(&bytes[start_ix..]);
+            // let i = self.scan_containers(&mut line_start);
+            // Some(line_start.bytes_scanned())
+            let skip_bytes = tree[node_ix].item.start.saturating_sub(ix);
+            Some(skip_bytes)
         } else {
             None
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1239,7 +1239,7 @@ impl<'a> FirstPass<'a> {
     /// Tries to parse a reference label, which can be interrupted by new blocks.
     /// On success, returns the number of bytes of the label and the label itself.
     fn parse_refdef_label(&self, start: usize) -> Option<(usize, CowStr<'a>)> {
-        scan_link_label_rest(&self.text[start..], |bytes| {
+        scan_link_label_rest(&self.text[start..], &|bytes| {
             let mut line_start = LineStart::new(bytes);
             let _ = scan_containers(&self.tree, &mut line_start);
             let bytes_scanned = line_start.bytes_scanned();
@@ -1687,10 +1687,10 @@ fn scan_link_label<'text, 'tree>(
         Some(line_start.bytes_scanned())
     };
     let pair = if b'^' == bytes[1] {
-        let (byte_index, cow) = scan_link_label_rest(&text[2..], linebreak_handler)?;
+        let (byte_index, cow) = scan_link_label_rest(&text[2..], &linebreak_handler)?;
         (byte_index + 2, ReferenceLabel::Footnote(cow))
     } else {
-        let (byte_index, cow) = scan_link_label_rest(&text[1..], linebreak_handler)?;
+        let (byte_index, cow) = scan_link_label_rest(&text[1..], &linebreak_handler)?;
         (byte_index + 1, ReferenceLabel::Link(cow))
     };
     Some(pair)

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -765,3 +765,44 @@ fn regression_test_56() {
 
     test_markdown_html(original, expected);
 }
+
+#[test]
+fn regression_test_57() {
+    let original = r##"[`cargo
+package`]
+
+[`cargo package`]: https://example.com
+"##;
+    let expected = r##"<p><a href="https://example.com"><code>cargo package</code></a></p>
+"##;
+
+    test_markdown_html(original, expected);
+}
+
+#[test]
+fn regression_test_58() {
+    let original = r##"> [`cargo
+> package`]
+
+[`cargo package`]: https://example.com
+"##;
+    let expected = r##"<blockquote>
+<p><a href="https://example.com"><code>cargo package</code></a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected);
+}
+
+#[test]
+fn regression_test_59() {
+    let original = r##"> `cargo
+> package`
+"##;
+    let expected = r##"<blockquote>
+<p><code>cargo package</code></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected);
+}

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -801,7 +801,6 @@ fn regression_test_59() {
 "##;
     let expected = r##"<blockquote>
 <p><code>cargo package</code></p>
-</blockquote>
 "##;
 
     test_markdown_html(original, expected);


### PR DESCRIPTION
There was an edge case with code spans within refdef labels. We relied on jumping to the next node whenever we encountered a newline inside a block (like a list or a blockquote), but code spans are always one node. This PR should cover this as well.

Closes #398.