### PR TITLE
Excluding unneeded folders from the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["markdown", "commonmark"]
 categories = ["text-processing"]
 edition = "2018"
 readme = "README.md"
+exclude = ["/third_party/**/*", "/tools/**/*", "/specs/**/*", "/fuzzer/**/*", "/benches/**/*", "/azure-pipelines.yml"]
 
 build = "build.rs"
 


### PR DESCRIPTION
The "tests" and "third_party" folders are not needed for the published package, and this change will simplify licenses and reduce the crate size.