### PR TITLE
Change the special character lookup tables to statics

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2570,7 +2570,7 @@ where
     }
 }
 
-const fn special_bytes() -> [bool; 256] {
+static SPECIAL_BYTES: [bool; 256] = {
     let mut bytes = [false; 256];
     bytes[b'<' as usize] = true;
     bytes[b'!' as usize] = true;
@@ -2586,7 +2586,7 @@ const fn special_bytes() -> [bool; 256] {
     bytes[b']' as usize] = true;
     bytes[b'&' as usize] = true;
     bytes
-}
+};
 
 pub(crate) fn scalar_iterate_special_bytes<F, T>(
     bytes: &[u8],
@@ -2596,11 +2596,10 @@ pub(crate) fn scalar_iterate_special_bytes<F, T>(
 where
     F: FnMut(usize, u8) -> LoopInstruction<Option<T>>,
 {
-    let special_bytes = special_bytes();
 
     while ix < bytes.len() {
         let b = bytes[ix];
-        if special_bytes[b as usize] {
+        if SPECIAL_BYTES[b as usize] {
             match callback(ix, b) {
                 LoopInstruction::ContinueAndSkip(skip) => {
                     ix += skip;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2563,7 +2563,12 @@ pub(crate) enum LoopInstruction<T> {
 /// called and the function returns immediately with the return value `(end_ix, opt_val)`.
 /// If `BreakAtWith(..)` is never returned, this function will return the first
 /// index that is outside the byteslice bound and a `None` value.
-fn iterate_special_bytes<F, T>(lut: LookupTable, bytes: &[u8], ix: usize, callback: F) -> (usize, Option<T>)
+fn iterate_special_bytes<F, T>(
+    lut: LookupTable,
+    bytes: &[u8],
+    ix: usize,
+    callback: F,
+) -> (usize, Option<T>)
 where
     F: FnMut(usize, u8) -> LoopInstruction<Option<T>>,
 {
@@ -2628,7 +2633,6 @@ pub(crate) fn scalar_iterate_special_bytes<F, T>(
 where
     F: FnMut(usize, u8) -> LoopInstruction<Option<T>>,
 {
-
     while ix < bytes.len() {
         let b = bytes[ix];
         if lut[b as usize] {

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -25,7 +25,7 @@ const VECTOR_SIZE: usize = std::mem::size_of::<__m128i>();
 /// special marker bytes. This is effectively a 128 element 2d bitvector,
 /// that can be indexed by a four bit row index (the lower nibble)
 /// and a three bit column index (upper nibble).
-const fn compute_lookup() -> [u8; 16] {
+static SPECIALS_LUT: [u8; 16] = {
     let mut lookup = [0u8; 16];
     lookup[(b'\n' & 0x0f) as usize] |= 1 << (b'\n' >> 4);
     lookup[(b'\r' & 0x0f) as usize] |= 1 << (b'\r' >> 4);
@@ -41,7 +41,7 @@ const fn compute_lookup() -> [u8; 16] {
     lookup[(b'!' & 0x0f) as usize] |= 1 << (b'!' >> 4);
     lookup[(b'`' & 0x0f) as usize] |= 1 << (b'`' >> 4);
     lookup
-}
+};
 
 /// Computes a bit mask for the given byteslice starting from the given index,
 /// where the 16 least significant bits indicate (by value of 1) whether or not
@@ -54,8 +54,7 @@ const fn compute_lookup() -> [u8; 16] {
 unsafe fn compute_mask(bytes: &[u8], ix: usize) -> i32 {
     debug_assert!(bytes.len() >= ix + VECTOR_SIZE);
 
-    let lookup = compute_lookup();
-    let bitmap = _mm_loadu_si128(lookup.as_ptr() as *const __m128i);
+    let bitmap = _mm_loadu_si128(SPECIALS_LUT.as_ptr() as *const __m128i);
     // Small lookup table to compute single bit bitshifts
     // for 16 bytes at once.
     let bitmask_lookup =

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -16,23 +16,24 @@
 //!
 //! [great overview]: http://0x80.pl/articles/simd-byte-lookup.html
 
-use crate::parse::LoopInstruction;
+use crate::parse::{LoopInstruction, ScalarLut};
 use core::arch::x86_64::*;
 
 const VECTOR_SIZE: usize = std::mem::size_of::<__m128i>();
+
+pub type MaybeSimdLut = (ScalarLut, SimdLut);
+pub type SimdLut = &'static [u8; 16];
 
 /// Generates a lookup table containing the bitmaps for our
 /// special marker bytes. This is effectively a 128 element 2d bitvector,
 /// that can be indexed by a four bit row index (the lower nibble)
 /// and a three bit column index (upper nibble).
-static SPECIALS_LUT: [u8; 16] = {
+const fn base_lut() -> [u8; 16] {
     let mut lookup = [0u8; 16];
     lookup[(b'\n' & 0x0f) as usize] |= 1 << (b'\n' >> 4);
     lookup[(b'\r' & 0x0f) as usize] |= 1 << (b'\r' >> 4);
     lookup[(b'*' & 0x0f) as usize] |= 1 << (b'*' >> 4);
     lookup[(b'_' & 0x0f) as usize] |= 1 << (b'_' >> 4);
-    lookup[(b'~' & 0x0f) as usize] |= 1 << (b'~' >> 4);
-    lookup[(b'|' & 0x0f) as usize] |= 1 << (b'|' >> 4);
     lookup[(b'&' & 0x0f) as usize] |= 1 << (b'&' >> 4);
     lookup[(b'\\' & 0x0f) as usize] |= 1 << (b'\\' >> 4);
     lookup[(b'[' & 0x0f) as usize] |= 1 << (b'[' >> 4);
@@ -41,7 +42,22 @@ static SPECIALS_LUT: [u8; 16] = {
     lookup[(b'!' & 0x0f) as usize] |= 1 << (b'!' >> 4);
     lookup[(b'`' & 0x0f) as usize] |= 1 << (b'`' >> 4);
     lookup
+}
+
+pub static SPECIALS_LUT: [u8; 16] = base_lut();
+pub static MAYBE_SPECIALS_LUT: MaybeSimdLut = (&crate::parse::SPECIAL_BYTES_LUT, &SPECIALS_LUT);
+
+/// A variant that also scans characters required for pulldown's extensions
+pub static SPECIALS_LUT_EXTENDED: [u8; 16] = {
+    let mut lookup = base_lut();
+    lookup[(b'|' & 0x0f) as usize] |= 1 << (b'|' >> 4);
+    lookup[(b'~' & 0x0f) as usize] |= 1 << (b'~' >> 4);
+    lookup
 };
+pub static MAYBE_SPECIALS_LUT_EXTENDED: MaybeSimdLut = (
+    &crate::parse::SPECIAL_BYTES_LUT_EXTENDED,
+    &SPECIALS_LUT_EXTENDED,
+);
 
 /// Computes a bit mask for the given byteslice starting from the given index,
 /// where the 16 least significant bits indicate (by value of 1) whether or not
@@ -51,10 +67,10 @@ static SPECIALS_LUT: [u8; 16] = {
 /// It is only safe to call this function when `bytes.len() >= ix + VECTOR_SIZE`.
 #[target_feature(enable = "ssse3")]
 #[inline]
-unsafe fn compute_mask(bytes: &[u8], ix: usize) -> i32 {
+unsafe fn compute_mask(lut: SimdLut, bytes: &[u8], ix: usize) -> i32 {
     debug_assert!(bytes.len() >= ix + VECTOR_SIZE);
 
-    let bitmap = _mm_loadu_si128(SPECIALS_LUT.as_ptr() as *const __m128i);
+    let bitmap = _mm_loadu_si128(lut.as_ptr() as *const __m128i);
     // Small lookup table to compute single bit bitshifts
     // for 16 bytes at once.
     let bitmask_lookup =
@@ -91,6 +107,7 @@ unsafe fn compute_mask(bytes: &[u8], ix: usize) -> i32 {
 /// number of bytes in callback return value otherwise.
 /// Returns the final index and a possible break value.
 pub(crate) fn iterate_special_bytes<F, T>(
+    luts: MaybeSimdLut,
     bytes: &[u8],
     ix: usize,
     callback: F,
@@ -99,9 +116,9 @@ where
     F: FnMut(usize, u8) -> LoopInstruction<Option<T>>,
 {
     if is_x86_feature_detected!("ssse3") && bytes.len() >= VECTOR_SIZE {
-        unsafe { simd_iterate_special_bytes(bytes, ix, callback) }
+        unsafe { simd_iterate_special_bytes(luts.1, bytes, ix, callback) }
     } else {
-        crate::parse::scalar_iterate_special_bytes(bytes, ix, callback)
+        crate::parse::scalar_iterate_special_bytes(luts.0, bytes, ix, callback)
     }
 }
 
@@ -136,6 +153,7 @@ where
 /// Important: only call this function when `bytes.len() >= 16`. Doing
 /// so otherwise may exhibit undefined behaviour.
 unsafe fn simd_iterate_special_bytes<F, T>(
+    lut: SimdLut,
     bytes: &[u8],
     mut ix: usize,
     mut callback: F,
@@ -147,7 +165,7 @@ where
     let upperbound = bytes.len() - VECTOR_SIZE;
 
     while ix < upperbound {
-        let mask = compute_mask(bytes, ix);
+        let mask = compute_mask(lut, bytes, ix);
         let block_start = ix;
         ix = match process_mask(mask, bytes, ix, &mut callback) {
             Ok(ix) => std::cmp::max(ix, VECTOR_SIZE + block_start),
@@ -157,7 +175,7 @@ where
 
     if bytes.len() > ix {
         // shift off the bytes at start we have already scanned
-        let mask = compute_mask(bytes, upperbound) >> ix - upperbound;
+        let mask = compute_mask(lut, bytes, upperbound) >> ix - upperbound;
         if let Err((end_ix, val)) = process_mask(mask, bytes, ix, &mut callback) {
             return (end_ix, val);
         }
@@ -168,12 +186,12 @@ where
 
 #[cfg(test)]
 mod simd_test {
-    use super::{iterate_special_bytes, LoopInstruction};
+    use super::{iterate_special_bytes, LoopInstruction, MAYBE_SPECIALS_LUT};
 
     fn check_expected_indices(bytes: &[u8], expected: &[usize], skip: usize) {
         let mut indices = vec![];
 
-        iterate_special_bytes::<_, i32>(bytes, 0, |ix, _byte_ty| {
+        iterate_special_bytes::<_, i32>(MAYBE_SPECIALS_LUT, bytes, 0, |ix, _byte_ty| {
             indices.push(ix);
             LoopInstruction::ContinueAndSkip(skip)
         });

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -216,18 +216,18 @@ mod simd_test {
 
     #[test]
     fn long_match() {
-        check_expected_indices("0123456789abcde~*bcd&f0".as_bytes(), &[15, 16, 20], 0);
+        check_expected_indices("0123456789abcde_*bcd&f0".as_bytes(), &[15, 16, 20], 0);
     }
 
     #[test]
     fn border_skip() {
-        check_expected_indices("0123456789abcde~~~~d&f0".as_bytes(), &[15, 20], 3);
+        check_expected_indices("0123456789abcde****d&f0".as_bytes(), &[15, 20], 3);
     }
 
     #[test]
     fn exhaustive_search() {
         let chars = [
-            b'\n', b'\r', b'*', b'_', b'~', b'|', b'&', b'\\', b'[', b']', b'<', b'!', b'`',
+            b'\n', b'\r', b'*', b'_', b'&', b'\\', b'[', b']', b'<', b'!', b'`',
         ];
 
         for &c in &chars {


### PR DESCRIPTION
See https://github.com/raphlinus/pulldown-cmark/issues/119#issuecomment-552158266

In addition, this PR also implements LUT switching so that the performance of plain CommonMark is not affected by adding extensions. The full commit message explains the performance impact of that change.

Here's the overall effect:

```
⌁  g/pulldown-cmark ╍ (static-scanner-lut) cargo bench --bench html_rendering -- --baseline baseline crdt_parse
    Finished bench [optimized] target(s) in 0.16s
     Running target/release/deps/html_rendering-09cbd52ae1f5c0d2
crdt_parse              time:   [337.56 us 338.25 us 338.96 us]
                        change: [-2.0951% -1.8117% -1.5011%] (p = 0.00 < 0.05)
                        Performance has improved.

```

(I would also note these benchmarks were running on a pretty noisy machine, and the baseline fluctuated quite a lot later (still centred on where it was). You can at the very least say that plain-spec perf is no longer dependent on the number of extensions & extra special chars that need to be scanned to support them.)