### PR TITLE
Remove benchmarks from Cargo exclusion list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["markdown", "commonmark"]
 categories = ["text-processing"]
 edition = "2018"
 readme = "README.md"
-exclude = ["/third_party/**/*", "/tools/**/*", "/specs/**/*", "/fuzzer/**/*", "/benches/**/*", "/azure-pipelines.yml"]
+exclude = ["/third_party/**/*", "/tools/**/*", "/specs/**/*", "/fuzzer/**/*", "/azure-pipelines.yml"]
 
 build = "build.rs"
 


### PR DESCRIPTION
When the benchmarks are excluded from the release, Cargo is not able
to locate the html_rendering benchmark and publication will fail.

There is something to be said for benchmark exclusion from releases,
but I don't see a way to exclude them from releases without removing
benchmarks altogether.