### PR TITLE
Allow paragraphs before tables

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -147,6 +147,13 @@ where
                     self.write("\n<p>")
                 }
             }
+            Tag::Options => {
+                if self.end_newline {
+                    self.write("<div class='options'>")
+                } else {
+                    self.write("\n<div class='options'>")
+                }
+            }
             Tag::Heading(level) => {
                 if self.end_newline {
                     self.end_newline = false;
@@ -291,6 +298,9 @@ where
         match tag {
             Tag::Paragraph => {
                 self.write("</p>\n")?;
+            }
+            Tag::Options => {
+                self.write("</div>\n")?;
             }
             Tag::Heading(level) => {
                 self.write("</")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,6 @@ pub enum Tag<'a> {
     /// A table row. Is used both for header rows as body rows. Contains only `TableCell`s.
     TableRow,
     TableCell,
-    Options,
 
     // span-level tags
     Emphasis,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,11 +127,13 @@ pub enum Tag<'a> {
     /// A table row. Is used both for header rows as body rows. Contains only `TableCell`s.
     TableRow,
     TableCell,
+    Options,
 
     // span-level tags
     Emphasis,
     Strong,
     Strikethrough,
+    Options,
 
     /// A link. The first field is the link type, the second the destination URL and the third is a title.
     Link(LinkType, CowStr<'a>, CowStr<'a>),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -54,6 +54,7 @@ pub(crate) enum ItemBody {
     Text,
     SoftBreak,
     HardBreak,
+    Options,
 
     // These are possible inline items, need to be resolved in second pass.
 
@@ -1350,6 +1351,7 @@ impl<'a, 'b> Iterator for OffsetIter<'a, 'b> {
 fn item_to_tag<'a>(item: &Item, allocs: &Allocations<'a>) -> Tag<'a> {
     match item.body {
         ItemBody::Paragraph => Tag::Paragraph,
+        ItemBody::Options => Tag::Options,
         ItemBody::Emphasis => Tag::Emphasis,
         ItemBody::Strong => Tag::Strong,
         ItemBody::Strikethrough => Tag::Strikethrough,
@@ -1401,6 +1403,7 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &Allocations<'a>) -> Eve
         ItemBody::Rule => return Event::Rule,
 
         ItemBody::Paragraph => Tag::Paragraph,
+        ItemBody::Options => Tag::Options,
         ItemBody::Emphasis => Tag::Emphasis,
         ItemBody::Strong => Tag::Strong,
         ItemBody::Strikethrough => Tag::Strikethrough,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -72,6 +72,7 @@ pub(crate) enum ItemBody {
     Emphasis,
     Strong,
     Strikethrough,
+    Options,
     Code(CowIndex),
     Link(LinkIndex),
     Image(LinkIndex),
@@ -1350,6 +1351,7 @@ impl<'a, 'b> Iterator for OffsetIter<'a, 'b> {
 fn item_to_tag<'a>(item: &Item, allocs: &Allocations<'a>) -> Tag<'a> {
     match item.body {
         ItemBody::Paragraph => Tag::Paragraph,
+        ItemBody::Options => Tag::Options,
         ItemBody::Emphasis => Tag::Emphasis,
         ItemBody::Strong => Tag::Strong,
         ItemBody::Strikethrough => Tag::Strikethrough,
@@ -1401,6 +1403,7 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &Allocations<'a>) -> Eve
         ItemBody::Rule => return Event::Rule,
 
         ItemBody::Paragraph => Tag::Paragraph,
+        ItemBody::Options => Tag::Options,
         ItemBody::Emphasis => Tag::Emphasis,
         ItemBody::Strong => Tag::Strong,
         ItemBody::Strikethrough => Tag::Strikethrough,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -72,7 +72,6 @@ pub(crate) enum ItemBody {
     Emphasis,
     Strong,
     Strikethrough,
-    Options,
     Code(CowIndex),
     Link(LinkIndex),
     Image(LinkIndex),
@@ -1351,7 +1350,6 @@ impl<'a, 'b> Iterator for OffsetIter<'a, 'b> {
 fn item_to_tag<'a>(item: &Item, allocs: &Allocations<'a>) -> Tag<'a> {
     match item.body {
         ItemBody::Paragraph => Tag::Paragraph,
-        ItemBody::Options => Tag::Options,
         ItemBody::Emphasis => Tag::Emphasis,
         ItemBody::Strong => Tag::Strong,
         ItemBody::Strikethrough => Tag::Strikethrough,
@@ -1403,7 +1401,6 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &Allocations<'a>) -> Eve
         ItemBody::Rule => return Event::Rule,
 
         ItemBody::Paragraph => Tag::Paragraph,
-        ItemBody::Options => Tag::Options,
         ItemBody::Emphasis => Tag::Emphasis,
         ItemBody::Strong => Tag::Strong,
         ItemBody::Strikethrough => Tag::Strikethrough,

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -604,6 +604,14 @@ pub(crate) fn scan_code_fence(data: &[u8]) -> Option<(usize, u8)> {
     }
 }
 
+pub(crate) fn scan_options_start(data: &[u8]) -> Option<usize> {
+    if data.starts_with(b":: ") {
+        Some(3)
+    } else {
+        None
+    }
+}
+
 pub(crate) fn scan_blockquote_start(data: &[u8]) -> Option<usize> {
     if data.starts_with(b"> ") {
         Some(2)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,6 +9,7 @@ use std::mem;
 use std::rc::{Rc, Weak};
 use tendril::stream::TendrilSink;
 
+mod options;
 mod suite;
 
 #[inline(never)]

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -42,3 +42,17 @@ paragraph
     html::push_html(&mut s, Parser::new(&original));
     assert_eq!(expected, s);
 }
+
+#[test]
+fn options_test4() {
+    let original = r##"# hello
+
+:: author: bambam
+paragraph
+
+"##;
+    let expected = "<h1>hello</h1>\n<div class='options'>author: bambam</div>\n<p>paragraph</p>\n";
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(&original));
+    assert_eq!(expected, s);
+}

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -1,0 +1,44 @@
+use pulldown_cmark::{html, Options, Parser};
+
+#[test]
+fn options_test1() {
+    let original = r##"# hello
+
+:: bam: bam
+paragraph
+
+"##;
+    let expected = "<h1>hello</h1>\n<div class='options'>bam: bam</div>\n<p>paragraph</p>\n";
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(&original));
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn options_test2() {
+    let original = r##"# hello
+
+:: author: "Franz Kafka", number: 42, apo: "(1;2;3)"
+paragraph
+
+"##;
+    let expected = "<h1>hello</h1>\n<div class='options'>author: &quot;Franz Kafka&quot;, number: 42, apo: &quot;(1;2;3)&quot;</div>\n<p>paragraph</p>\n";
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(&original));
+    assert_eq!(expected, s);
+}
+
+// options without newlines become part of the paragraph
+#[test]
+fn options_test3() {
+    let original = r##"# hello
+parapara
+:: bam: bam
+paragraph
+
+"##;
+    let expected = "<h1>hello</h1>\n<p>parapara\n:: bam: bam\nparagraph</p>\n";
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(&original));
+    assert_eq!(expected, s);
+}

--- a/tests/suite/gfm_table.rs
+++ b/tests/suite/gfm_table.rs
@@ -228,7 +228,7 @@ fn gfm_table_test_9() {
 </table>
 "##;
 
-    test_markdown_html(original, expected);
+    test_markdown_html(original, expected, false);
 }
 
 #[test]
@@ -262,5 +262,5 @@ Done
 <p>Done</p>
 "##;
 
-    test_markdown_html(original, expected);
+    test_markdown_html(original, expected, false);
 }

--- a/tests/suite/gfm_table.rs
+++ b/tests/suite/gfm_table.rs
@@ -203,3 +203,64 @@ fn gfm_table_test_8() {
 
     test_markdown_html(original, expected, false);
 }
+
+#[test]
+fn gfm_table_test_9() {
+    let original = r##"Hello World
+| abc | def |
+| --- | --- |
+| bar | baz |
+"##;
+    let expected = r##"<p>Hello World</p>
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>
+"##;
+
+    test_markdown_html(original, expected);
+}
+
+#[test]
+fn gfm_table_test_10() {
+    let original = r##"
+# A Header
+
+Hello World
+| abc | def |
+| --- | --- |
+| bar | baz |
+
+Done
+"##;
+    let expected = r##"<h1>A Header</h1>
+<p>Hello World</p>
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>
+<p>Done</p>
+"##;
+
+    test_markdown_html(original, expected);
+}

--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -11,3 +11,4 @@ mod regression;
 mod smart_punct;
 mod spec;
 mod table;
+mod options;


### PR DESCRIPTION
I'm running into all kinds of corner cases with one of my projects, this being another one. It is even more tricky because tables are not part of CommonMark so it is less clear what the right behavior is. The problem this PR solves is that a table that has a paragraph right before it will not be parsed:

```
Hello
| abc | def |
| --- | --- |
| bar | baz |
```

Becomes a long paragraph the table syntax as part of the paragraph.

This PR fixes that and inserts a `Hello` paragraph before the table in the parsed markdown. In my project, I kind of rely on the possibility of having a paragraph before an element which is how I ran into this issue. I did some research to see how other projects, notably GitHub render the example above.
Interestingly, GitHub exhibits the same issue in their markdown parsing, while [this online editor](https://jbt.github.io/markdown-editor/) supports it just fine.

However, other examples, such as

```
# Hello
| abc | def |
| --- | --- |
| bar | baz |
```

render correctly on GitHub. It is only paragraphs, that are not supported right before a table. Therefore, at least to me, this feels more like an accidental bug than correct behavior.

Personally, for me, it would be great if this would be merged, as I'd need to continue using a fork otherwise. Another, maybe, viable option might be to have this behavior be optional via a feature flag (although I can see that this is a road that, once taken, can lead to madness if more and more of the non-standardized idiosyncratic markdown _features_ end up as feature flags).

This PR also contains tests, and I'd be more than happy to improve the code if it is not up to the quality standards of pulldown-cmark.

