### PR TITLE
Treat broken reference links as links

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3118,4 +3118,19 @@ mod test {
         }
         assert_eq!(found, 1);
     }
+
+    #[test]
+    fn broken_links_called_only_once() {
+        use std::cell::Cell;
+
+        let markdown = "See also [`g()`][crate::g].";
+        let times_called = Cell::new(0);
+        let callback = |_: &str, _: &str| {
+            times_called.set(times_called.get() + 1);
+            None
+        };
+        let parser = Parser::new_with_broken_link_callback(markdown, Options::empty(), Some(&callback));
+        for _ in parser {}
+        assert_eq!(times_called.get(), 1);
+    }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3133,14 +3133,18 @@ mod test {
     fn broken_links_called_only_once() {
         use std::cell::Cell;
 
-        let markdown = "See also [`g()`][crate::g].";
-        let times_called = Cell::new(0);
-        let callback = |_: &str, _: &str| {
-            times_called.set(times_called.get() + 1);
-            None
-        };
-        let parser = Parser::new_with_broken_link_callback(markdown, Options::empty(), Some(&callback));
-        for _ in parser {}
-        assert_eq!(times_called.get(), 1);
+        for &(markdown, expected) in &[
+            ("See also [`g()`][crate::g].", 1),
+            ("[brokenlink1] some other node [brokenlink2]", 2),
+        ] {
+            let times_called = Cell::new(0);
+            let callback = |_: &str, _: &str| {
+                times_called.set(times_called.get() + 1);
+                None
+            };
+            let parser = Parser::new_with_broken_link_callback(markdown, Options::empty(), Some(&callback));
+            for _ in parser {}
+            assert_eq!(times_called.get(), expected);
+        }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2154,16 +2154,7 @@ impl<'a> Parser<'a> {
                                 // [shortcut]
                                 //
                                 // [shortcut]: /blah
-                                RefScan::Failed => {
-                                    if saw_broken {
-                                        saw_broken = false;
-                                        prev = cur;
-                                        cur = self.tree[cur_ix].next;
-                                        continue;
-                                    } else {
-                                        (next, LinkType::Shortcut)
-                                    }
-                                }
+                                RefScan::Failed => (next, LinkType::Shortcut),
                             };
 
                             // (label, source_ix end)
@@ -2209,15 +2200,20 @@ impl<'a> Parser<'a> {
                                         (link_type, url, title)
                                     })
                                     .or_else(|| {
-                                        self.broken_link_callback
-                                            .and_then(|callback| {
-                                                // looked for matching definition, but didn't find it. try to fix
-                                                // link with callback, if it is defined
-                                                callback(link_label.as_ref(), link_label.as_ref())
-                                            })
-                                            .map(|(url, title)| {
-                                                (link_type.to_unknown(), url.into(), title.into())
-                                            })
+                                        if saw_broken {
+                                            saw_broken = false;
+                                            None
+                                        } else {
+                                            self.broken_link_callback
+                                                .and_then(|callback| {
+                                                    // looked for matching definition, but didn't find it. try to fix
+                                                    // link with callback, if it is defined
+                                                    callback(link_label.as_ref(), link_label.as_ref())
+                                                })
+                                                .map(|(url, title)| {
+                                                    (link_type.to_unknown(), url.into(), title.into())
+                                                })
+                                        }
                                     });
 
                                 if let Some((def_link_type, url, title)) = type_url_title {


### PR DESCRIPTION
This ensures that broken_link_callback will only see broken links once.

Closes #444

<details><summary>Outdated: trouble with FnMut</summary>

I tried to add the following test, but it fails because callbacks are only allowed to be `Fn`, not `FnMut`:
```rust
    #[test]
    fn broken_links_called_only_once() {
        let markdown = "See also [`g()`][crate::g].";
        let mut times_called = 0;
        let mut callback = |_: &str, _: &str| {
            times_called += 1;
            None
        };
        let parser = Parser::new_with_broken_link_callback(markdown, Options::empty(), Some(&callback));
        for _ in parser {}
        assert_eq!(times_called, 1);
    }
```
```
error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnMut`
    --> src/parse.rs:3133:28
     |
3133 |         let mut callback = |_: &str, _: &str| {
     |                            ^^^^^^^^^^^^^^^^^^ this closure implements `FnMut`, not `Fn`
3134 |             times_called += 1;
     |             ------------ closure is `FnMut` because it mutates the variable `times_called` here
...
3137 |         let parser = Parser::new_with_broken_link_callback(markdown, Options::empty(), Some(&callback));
     |                                                                                             --------- the requirement to implement `Fn` derives from here
```
I tried allowing FnMut closures, but that had all sorts of other things that broke, including needing to pass in `Some(&mut closure)` instead of `Some(&closure)` and removing the `Clone` impl for `Parser`. Let me know if you want me to follow up with that, I'm not sure what the best approach is there.

</details>