### PR TITLE
Don't emit footnote references when option is not set

### DIFF
--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -4,9 +4,9 @@
 pub use super::test_markdown_html;
 
 mod footnotes;
-mod regression;
-mod table;
-mod spec;
-mod gfm_table;
 mod gfm_strikethrough;
+mod gfm_table;
 mod gfm_tasklist;
+mod regression;
+mod spec;
+mod table;


### PR DESCRIPTION
We would correctly skip parsing footnote definitions when the option was not set, but we'd still emit references.

Now, footnote references (of the form [^ref]) are treated as regular links unless footnotes are enabled in the options.

Fixes https://github.com/raphlinus/pulldown-cmark/issues/459.