### PR TITLE
Export HTML and href escape functions

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -21,10 +21,9 @@
 //! HTML renderer that takes an iterator of events as input.
 
 use std::collections::HashMap;
-use std::fmt::{Arguments, Write as FmtWrite};
-use std::io::{self, ErrorKind, Write};
+use std::io::{self, Write};
 
-use crate::escape::{escape_href, escape_html};
+use crate::escape::{escape_href, escape_html, StrWrite, WriteWrapper};
 use crate::parse::Event::*;
 use crate::parse::{Alignment, CodeBlockKind, Event, LinkType, Tag};
 use crate::strings::CowStr;
@@ -32,64 +31,6 @@ use crate::strings::CowStr;
 enum TableState {
     Head,
     Body,
-}
-
-/// This wrapper exists because we can't have both a blanket implementation
-/// for all types implementing `Write` and types of the for `&mut W` where
-/// `W: StrWrite`. Since we need the latter a lot, we choose to wrap
-/// `Write` types.
-struct WriteWrapper<W>(W);
-
-/// Trait that allows writing string slices. This is basically an extension
-/// of `std::io::Write` in order to include `String`.
-pub(crate) trait StrWrite {
-    fn write_str(&mut self, s: &str) -> io::Result<()>;
-
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()>;
-}
-
-impl<W> StrWrite for WriteWrapper<W>
-where
-    W: Write,
-{
-    #[inline]
-    fn write_str(&mut self, s: &str) -> io::Result<()> {
-        self.0.write_all(s.as_bytes())
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
-        self.0.write_fmt(args)
-    }
-}
-
-impl<'w> StrWrite for String {
-    #[inline]
-    fn write_str(&mut self, s: &str) -> io::Result<()> {
-        self.push_str(s);
-        Ok(())
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
-        // FIXME: translate fmt error to io error?
-        FmtWrite::write_fmt(self, args).map_err(|_| ErrorKind::Other.into())
-    }
-}
-
-impl<W> StrWrite for &'_ mut W
-where
-    W: StrWrite,
-{
-    #[inline]
-    fn write_str(&mut self, s: &str) -> io::Result<()> {
-        (**self).write_str(s)
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
-        (**self).write_fmt(args)
-    }
 }
 
 struct HtmlWriter<'a, I, W> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ extern crate bitflags;
 extern crate unicase;
 
 mod entities;
-mod escape;
+pub mod escape;
 mod linklabel;
 mod parse;
 mod puncttable;

--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -4,9 +4,9 @@
 pub use super::test_markdown_html;
 
 mod footnotes;
-mod regression;
-mod table;
-mod spec;
-mod gfm_table;
 mod gfm_strikethrough;
+mod gfm_table;
 mod gfm_tasklist;
+mod regression;
+mod spec;
+mod table;


### PR DESCRIPTION
These can be used when implementing custom HTML renderers.

Addresses https://github.com/raphlinus/pulldown-cmark/issues/465.