### PR TITLE
A new broken link callback design

### DIFF
--- a/examples/broken-link-callbacks.rs
+++ b/examples/broken-link-callbacks.rs
@@ -9,12 +9,12 @@ fn main() {
     // Setup callback that sets the URL and title when it encounters
     // a reference to our home page.
     let callback = &mut |broken_link: BrokenLink| {
-        if broken_link.reference.as_ref() == "my website" {
+        if broken_link.reference == "my website" {
             println!(
                 "Replacing the markdown `{}` of type {:?} with a working link",
                 &input[broken_link.span], broken_link.link_type,
             );
-            Some(("http;//example.com".into(), "my example website".into()))
+            Some(("http://example.com".into(), "my example website".into()))
         } else {
             None
         }
@@ -29,7 +29,7 @@ fn main() {
 
     // Check that the output is what we expected.
     let expected_html: &str =
-        "<p>Hello world, check out <a href=\"http;//example.com\" title=\"my example website\">my website</a>.</p>\n";
+        "<p>Hello world, check out <a href=\"http://example.com\" title=\"my example website\">my website</a>.</p>\n";
     assert_eq!(expected_html, &html_output);
 
     // Write result to stdout.

--- a/examples/broken-link-callbacks.rs
+++ b/examples/broken-link-callbacks.rs
@@ -1,0 +1,37 @@
+extern crate pulldown_cmark;
+
+use pulldown_cmark::{html, BrokenLink, Options, Parser};
+
+fn main() {
+    let input: &str = "Hello world, check out [my website][].";
+    println!("Parsing the following markdown string:\n{}", input);
+
+    // Setup callback that sets the URL and title when it encounters
+    // a reference to our home page.
+    let callback = &mut |broken_link: BrokenLink| {
+        if broken_link.reference.as_ref() == "my website" {
+            println!(
+                "Replacing the markdown `{}` of type {:?} with a working link",
+                &input[broken_link.span], broken_link.link_type,
+            );
+            Some(("http;//example.com".into(), "my example website".into()))
+        } else {
+            None
+        }
+    };
+
+    // Create a parser with our callback function for broken links.
+    let parser = Parser::new_with_broken_link_callback(input, Options::empty(), Some(callback));
+
+    // Write to String buffer.
+    let mut html_output: String = String::with_capacity(input.len() * 3 / 2);
+    html::push_html(&mut html_output, parser);
+
+    // Check that the output is what we expected.
+    let expected_html: &str =
+        "<p>Hello world, check out <a href=\"http;//example.com\" title=\"my example website\">my website</a>.</p>\n";
+    assert_eq!(expected_html, &html_output);
+
+    // Write result to stdout.
+    println!("\nHTML output:\n{}", &html_output);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,6 @@ mod tree;
 mod simd;
 
 pub use crate::parse::{
-    Alignment, CodeBlockKind, Event, LinkType, OffsetIter, Options, Parser, Tag,
+    Alignment, BrokenLink, CodeBlockKind, Event, LinkType, OffsetIter, Options, Parser, Tag,
 };
 pub use crate::strings::{CowStr, InlineStr};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -279,9 +279,9 @@ enum TableParseMode {
 }
 
 pub struct BrokenLink<'a> {
-    pub span: ::std::ops::Range<usize>,
+    pub span: std::ops::Range<usize>,
     pub link_type: LinkType,
-    pub reference: &'a CowStr<'a>,
+    pub reference: &'a str,
 }
 
 /// State for the first parsing pass.
@@ -2255,7 +2255,7 @@ impl<'a> Parser<'a> {
                                                 let broken_link = BrokenLink {
                                                     span: (self.tree[tos.node].item.start)..end,
                                                     link_type: link_type,
-                                                    reference: &link_label,
+                                                    reference: link_label.as_ref(),
                                                 };
 
                                                 callback(broken_link).map(|(url, title)| {
@@ -3161,7 +3161,7 @@ mod test {
     fn simple_broken_link_callback() {
         let test_str = "This is a link w/o def: [hello][world]";
         let mut callback = |broken_link: BrokenLink| {
-            assert_eq!("world", broken_link.reference.as_ref());
+            assert_eq!("world", broken_link.reference);
             assert_eq!(&test_str[broken_link.span], "[hello][world]");
             let url = "YOLO".into();
             let title = "SWAG".to_owned().into();


### PR DESCRIPTION
This is a ~~WIP~~ PR to address several outstanding issues with the current broken link callback design.

Firstly, it provides additional data (source mapping, link type) to the callback to improve diagnostics (https://github.com/raphlinus/pulldown-cmark/issues/373) and help disambiguate links with identical references (https://github.com/raphlinus/pulldown-cmark/issues/165). Further, this design also prevents the callback from being called twice on the same reference (https://github.com/raphlinus/pulldown-cmark/issues/444). And lastly, the callback now returns `CowStr`s, so that it is possible to generate titles and urls without memory allocations, for example when they are static strings or derived from text in the source.

Feedback is greatly appreciated. Would this cover your use-cases? Is this an improvement over the old design?

cc @euclio @jyn514 @GuillaumeGomez 