### PR TITLE
Fix bug with tab indented codeblocks being interpreted as lists

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -814,3 +814,11 @@ lo"></p>
 </blockquote>
 </blockquote>
 ````````````````````````````````
+
+ISSUE 487
+
+```````````````````````````````` example
+	-	the whitespace here are tabs
+.
+<pre><code>-	the whitespace here are tabs</code></pre>
+````````````````````````````````

--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -820,5 +820,6 @@ ISSUE 487
 ```````````````````````````````` example
 	-	the whitespace here are tabs
 .
-<pre><code>-	the whitespace here are tabs</code></pre>
+<pre><code>-	the whitespace here are tabs
+</code></pre>
 ````````````````````````````````

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -207,8 +207,8 @@ impl<'a> LineStart<'a> {
     /// bullet list markers, it will be one of b'-', b'+', or b'*'.
     pub(crate) fn scan_list_marker(&mut self) -> Option<(u8, u64, usize)> {
         let save = self.clone();
-        let indent = self.scan_space_upto(3);
-        if self.ix < self.bytes.len() {
+        let indent = self.scan_space_upto(4);
+        if indent < 4 && self.ix < self.bytes.len() {
             let c = self.bytes[self.ix];
             if c == b'-' || c == b'+' || c == b'*' {
                 if self.ix >= self.min_hrule_offset {

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -956,7 +956,8 @@ lo"></p>
 fn regression_test_67() {
     let original = r##"	-	the whitespace here are tabs
 "##;
-    let expected = r##"<pre><code>-	the whitespace here are tabs</code></pre>
+    let expected = r##"<pre><code>-	the whitespace here are tabs
+</code></pre>
 "##;
 
     test_markdown_html(original, expected, false);

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -951,3 +951,13 @@ lo"></p>
 
     test_markdown_html(original, expected, false);
 }
+
+#[test]
+fn regression_test_67() {
+    let original = r##"	-	the whitespace here are tabs
+"##;
+    let expected = r##"<pre><code>-	the whitespace here are tabs</code></pre>
+"##;
+
+    test_markdown_html(original, expected, false);
+}


### PR DESCRIPTION
This was fairly subtle. We would scan up to 3 spaces, consuming a tab and leaving one space in the buffer. But it would also already bump the internal text pointer forward past the tab, so if we'd find a list marker there, it would incorrectly be interpreted as the list because we didn't look at the space buffer.

Fixes https://github.com/raphlinus/pulldown-cmark/issues/487.