### PR TITLE
Add convenience empty InlineStr ctor

### DIFF
--- a/src/strings.rs
+++ b/src/strings.rs
@@ -19,6 +19,15 @@ pub struct InlineStr {
     inner: [u8; MAX_INLINE_STR_LEN],
 }
 
+impl InlineStr {
+    // Returns an empty `InlineStr`.
+    pub fn empty() -> Self {
+        Self {
+            inner: [0; MAX_INLINE_STR_LEN],
+        }
+    }
+}
+
 impl<'a> AsRef<str> for InlineStr {
     fn as_ref(&self) -> &str {
         self.deref()


### PR DESCRIPTION
This helps avoid writing `use std::convert::TryFrom; InlineStr::try_from("").unwrap()`, as seen in https://github.com/rust-analyzer/rust-analyzer/pull/6217/files#diff-4e6b4f7c9db0646b27efab3b7c999593ba2480b3afe3312889ff471251bc870bR72.