### PR TITLE
Relax broken link callback requirements

### DIFF
--- a/examples/broken-link-callbacks.rs
+++ b/examples/broken-link-callbacks.rs
@@ -9,10 +9,10 @@ fn main() {
     // Setup callback that sets the URL and title when it encounters
     // a reference to our home page.
     let callback = &mut |broken_link: BrokenLink| {
-        if broken_link.reference == "my website" {
+        if broken_link.reference.as_ref() == "my website" {
             println!(
                 "Replacing the markdown `{}` of type {:?} with a working link",
-                &input[broken_link.span], broken_link.link_type,
+                broken_link.source(), broken_link.link_type,
             );
             Some(("http://example.com".into(), "my example website".into()))
         } else {

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -238,7 +238,7 @@ fn html_test_broken_callback() {
     let mut s = String::new();
 
     let mut callback = |broken_link: BrokenLink| {
-        if broken_link.reference == "foo" || broken_link.reference == "baz" {
+        if broken_link.reference.as_ref() == "foo" || broken_link.reference.as_ref() == "baz" {
             Some(("https://replaced.example.org".into(), "some title".into()))
         } else {
             None


### PR DESCRIPTION
Hi,
    it's nice to see the broken link callback's got some refactoring.
However, I find the new design hard to use.
In particular, it seems it's not possible with the current design for the parser
iterator to escape the function scope in which the callback lives
(unless I use `unsafe`).

In the PR I propose a change of the broken link requirements to make this possible.

You can see a simplified version of my use-case in the added `broken_link_callback_move` unit test.

The important bit is that the `BrokenLink` type carries the lifetime of the input
rather than some random internal stack lifetime, which makes it possible to
use a HRTB to store the closure in a box.

I also relaxed `FnMut` to just `Fn`, it seems to me to make the usage easier,
but if you don't like it I don't insist on this part.

Let me know if this makes sense (or maybe whether I missed something).
Thanks! :slightly_smiling_face: 