### PR TITLE
Export BrokenLinkCallback from the 'parse' module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod scanners;
 mod strings;
 mod tree;
 
-pub use crate::parse::{BrokenLink, OffsetIter, Parser};
+pub use crate::parse::{BrokenLink, BrokenLinkCallback, OffsetIter, Parser};
 pub use crate::strings::{CowStr, InlineStr};
 
 /// Codeblock kind.


### PR DESCRIPTION
Fixes #498 