### PR TITLE
Use enum for heading level.

### DIFF
--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -3,12 +3,15 @@
 
 use std::cmp::max;
 
-use crate::linklabel::{scan_link_label_rest, LinkLabel};
 use crate::parse::{scan_containers, Allocations, Item, ItemBody, LinkDef};
 use crate::scanners::*;
 use crate::strings::CowStr;
 use crate::tree::{Tree, TreeIndex};
 use crate::Options;
+use crate::{
+    linklabel::{scan_link_label_rest, LinkLabel},
+    HeadingLevel,
+};
 
 use unicase::UniCase;
 
@@ -986,13 +989,13 @@ impl<'a, 'b> FirstPass<'a, 'b> {
     /// Parse an ATX heading.
     ///
     /// Returns index of start of next line.
-    fn parse_atx_heading(&mut self, mut ix: usize, atx_size: usize) -> usize {
+    fn parse_atx_heading(&mut self, mut ix: usize, atx_level: HeadingLevel) -> usize {
         let heading_ix = self.tree.append(Item {
             start: ix,
             end: 0, // set later
-            body: ItemBody::Heading(atx_size as u32),
+            body: ItemBody::Heading(atx_level),
         });
-        ix += atx_size;
+        ix += atx_level as usize;
         // next char is space or eol (guaranteed by scan_atx_heading)
         let bytes = self.text.as_bytes();
         if let Some(eol_bytes) = scan_eol(&bytes[ix..]) {

--- a/src/html.rs
+++ b/src/html.rs
@@ -150,9 +150,9 @@ where
             Tag::Heading(level) => {
                 if self.end_newline {
                     self.end_newline = false;
-                    write!(&mut self.writer, "<h{}>", level)
+                    write!(&mut self.writer, "<{}>", level)
                 } else {
-                    write!(&mut self.writer, "\n<h{}>", level)
+                    write!(&mut self.writer, "\n<{}>", level)
                 }
             }
             Tag::Table(alignments) => {
@@ -293,7 +293,7 @@ where
                 self.write("</p>\n")?;
             }
             Tag::Heading(level) => {
-                self.write("</h")?;
+                self.write("</")?;
                 write!(&mut self.writer, "{}", level)?;
                 self.write(">\n")?;
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -32,7 +32,7 @@ use crate::linklabel::{scan_link_label_rest, LinkLabel, ReferenceLabel};
 use crate::scanners::*;
 use crate::strings::CowStr;
 use crate::tree::{Tree, TreeIndex};
-use crate::{Alignment, CodeBlockKind, Event, LinkType, Options, Tag};
+use crate::{Alignment, CodeBlockKind, Event, HeadingLevel, LinkType, Options, Tag};
 
 // Allowing arbitrary depth nested parentheses inside link destinations
 // can create denial of service vulnerabilities if we're not careful.
@@ -79,7 +79,7 @@ pub(crate) enum ItemBody {
     TaskListMarker(bool), // true for checked
 
     Rule,
-    Heading(u32), // heading level
+    Heading(HeadingLevel), // heading level
     FencedCodeBlock(CowIndex),
     IndentCodeBlock,
     Html,


### PR DESCRIPTION
Fixes #501. As discussed, this is a minor breaking change. 

This diff converts the `u32` that we used as the header level into a enum, `HeadingLevel`.

High level changelog:
 - Introduced a new public enum, `HeadingLevel`
 - As this is a public enum, all easily derived and implementable common traits are implemented, including `TryFrom` and `Display`.
 - Use the `Display` trait internally, so `start_tag` and `end_tag` no longer prefixes `h` in the respective areas.
 - Since `HeadingLevel` implements `TryFrom`, `scan_atx_heading` now uses `try_from` instead of hard-coding the heading level bounds in the function.