### PR TITLE
Make `html` and `escape` modules optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,18 @@ harness = false
 name = "markdown-it"
 harness = false
 
+[[example]]
+name = "event-filter"
+required-features = ["html"]
+
+[[example]]
+name = "string-to-string"
+required-features = ["html"]
+
+[[example]]
+name = "broken-link-callbacks"
+required-features = ["html"]
+
 [dependencies]
 bitflags = "1.2"
 unicase = "2.6"
@@ -48,6 +60,7 @@ serde_json = "1.0.61"
 bincode = "1.3.1"
 
 [features]
-default = ["getopts"]
+default = ["getopts", "html"]
 gen-tests = []
 simd = []
+html = []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,8 @@ steps:
     displayName: Cargo test with simd feature enabled
   - script: cargo test --all --features=serde
     displayName: Cargo test with serde feature enabled
+  - script: cargo test --all --no-default-features
+    displayName: Cargo test without default features    
   - script: cargo run --release -- --regressions
     workingDirectory: fuzzer
     displayName: Test for superlinear time regressions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! # Example
 //! ```rust
-//! use pulldown_cmark::{Parser, Options, html};
+//! use pulldown_cmark::{Parser, Options};
 //!
 //! let markdown_input = "Hello world, this is a ~~complicated~~ *very simple* example.";
 //!
@@ -38,13 +38,15 @@
 //! options.insert(Options::ENABLE_STRIKETHROUGH);
 //! let parser = Parser::new_ext(markdown_input, options);
 //!
+//! # #[cfg(feature = "html")] {
 //! // Write to String buffer.
 //! let mut html_output = String::new();
-//! html::push_html(&mut html_output, parser);
+//! pulldown_cmark::html::push_html(&mut html_output, parser);
 //!
 //! // Check that the output is what we expected.
 //! let expected_html = "<p>Hello world, this is a <del>complicated</del> <em>very simple</em> example.</p>\n";
 //! assert_eq!(expected_html, &html_output);
+//! # }
 //! ```
 
 // When compiled for the rustc compiler itself we want to make sure that this is
@@ -58,10 +60,12 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "html")]
 pub mod html;
+#[cfg(feature = "html")]
+pub mod escape;
 
 mod entities;
-pub mod escape;
 mod firstpass;
 mod linklabel;
 mod parse;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1671,6 +1671,7 @@ mod test {
     }
 
     // FIXME: add this one regression suite
+    #[cfg(feature = "html")]
     #[test]
     fn link_def_at_eof() {
         let test_str = "[My site][world]\n\n[world]: https://vincentprouillet.com";
@@ -1681,6 +1682,7 @@ mod test {
         assert_eq!(expected, buf);
     }
 
+    #[cfg(feature = "html")]
     #[test]
     fn no_footnote_refs_without_option() {
         let test_str = "a [^a]\n\n[^a]: yolo";
@@ -1691,6 +1693,7 @@ mod test {
         assert_eq!(expected, buf);
     }
 
+    #[cfg(feature = "html")]
     #[test]
     fn ref_def_at_eof() {
         let test_str = "[test]:\\";
@@ -1701,6 +1704,7 @@ mod test {
         assert_eq!(expected, buf);
     }
 
+    #[cfg(feature = "html")]
     #[test]
     fn ref_def_cr_lf() {
         let test_str = "[a]: /u\r\n\n[a]";
@@ -1711,6 +1715,7 @@ mod test {
         assert_eq!(expected, buf);
     }
 
+    #[cfg(feature = "html")]
     #[test]
     fn no_dest_refdef() {
         let test_str = "[a]:";

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -1,4 +1,5 @@
 // Tests for HTML spec.
+#![cfg(feature = "html")]
 
 use pulldown_cmark::{html, BrokenLink, Options, Parser};
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "html")]
+
 use html5ever::serialize::{serialize, SerializeOpts};
 use html5ever::{driver as html, local_name, namespace_url, ns, QualName};
 use markup5ever_rcdom::{Handle, NodeData, RcDom, SerializableHandle};


### PR DESCRIPTION
This PR introduces a new enabled-by-default-feature `html`. If this feature is enabled, there are no functional differences. If it is disabled, the `html` and `escape` modules are _not_ compiled. This is helpful, if a dependent crate does not require any HTML rendering.

Note, that this will __break__ user crates, that use `--no-default-features` and also use one of the two modules in question. Therefore I understand, if this PR cannot be merged.

Note, that some tests and examples need new annotations, as they require the `html` module.