### PR TITLE
add rendering options for target="_blank"

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -27,7 +27,7 @@ use crate::escape::{escape_href, escape_html, StrWrite, WriteWrapper};
 use crate::strings::CowStr;
 use crate::Event::*;
 use crate::{Alignment, CodeBlockKind, Event, LinkType, Tag};
-use crate::{RenderingOptions};
+use crate::RenderingOptions;
 
 enum TableState {
     Head,

--- a/src/html.rs
+++ b/src/html.rs
@@ -27,6 +27,7 @@ use crate::escape::{escape_href, escape_html, StrWrite, WriteWrapper};
 use crate::strings::CowStr;
 use crate::Event::*;
 use crate::{Alignment, CodeBlockKind, Event, LinkType, Tag};
+use crate::{RenderingOptions};
 
 enum TableState {
     Head,
@@ -47,6 +48,7 @@ struct HtmlWriter<'a, I, W> {
     table_alignments: Vec<Alignment>,
     table_cell_index: usize,
     numbers: HashMap<CowStr<'a>, usize>,
+    options: RenderingOptions,
 }
 
 impl<'a, I, W> HtmlWriter<'a, I, W>
@@ -55,6 +57,10 @@ where
     W: StrWrite,
 {
     fn new(iter: I, writer: W) -> Self {
+        HtmlWriter::new_ext(iter, writer, RenderingOptions::empty())
+    }
+
+    fn new_ext(iter: I, writer: W, options: RenderingOptions) -> Self {
         Self {
             iter,
             writer,
@@ -63,6 +69,7 @@ where
             table_alignments: vec![],
             table_cell_index: 0,
             numbers: HashMap::new(),
+            options,
         }
     }
 
@@ -252,7 +259,11 @@ where
                 self.write("\">")
             }
             Tag::Link(_link_type, dest, title) => {
-                self.write("<a href=\"")?;
+                if self.options.contains(RenderingOptions::OPEN_LINK_IN_NEW_TAB) {
+                    self.write("<a target=\"_blank\" href=\"")?;
+                } else {
+                    self.write("<a href=\"")?;
+                }
                 escape_href(&mut self.writer, &dest)?;
                 if !title.is_empty() {
                     self.write("\" title=\"")?;
@@ -417,6 +428,13 @@ where
     I: Iterator<Item = Event<'a>>,
 {
     HtmlWriter::new(iter, s).run().unwrap();
+}
+
+pub fn push_html_ext<'a, I>(s: &mut String, iter: I, options: RenderingOptions)
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    HtmlWriter::new_ext(iter, s, options).run().unwrap();
 }
 
 /// Iterate over an `Iterator` of `Event`s, generate HTML for each `Event`, and

--- a/src/html.rs
+++ b/src/html.rs
@@ -260,7 +260,7 @@ where
             }
             Tag::Link(_link_type, dest, title) => {
                 if self.options.contains(RenderingOptions::OPEN_LINK_IN_NEW_TAB) {
-                    self.write("<a target=\"_blank\" href=\"")?;
+                    self.write("<a target=\"_blank\" rel=\"noreferrer\" href=\"")?;
                 } else {
                     self.write("<a href=\"")?;
                 }
@@ -430,6 +430,27 @@ where
     HtmlWriter::new(iter, s).run().unwrap();
 }
 
+/// Iterate over an `Iterator` of `Event`s, generate HTML for each `Event`, and
+/// push it to a `String`. Can specify rendering extensions.
+///
+/// # Examples
+///
+/// ```
+/// use pulldown_cmark::{html, Parser, RenderingOptions};
+///
+/// let markdown_str = r#"[my link](https://mydomain.net)"#;
+/// let parser = Parser::new(markdown_str);
+///
+/// let mut rendering_options = RenderingOptions::empty();
+/// rendering_options.insert(RenderingOptions::OPEN_LINK_IN_NEW_TAB);
+///
+/// let mut html_buf = String::new();
+/// html::push_html_ext(&mut html_buf, parser, rendering_options);
+///
+/// assert_eq!(html_buf, 
+/// r#"<p><a target="_blank" rel="noreferrer" href="https://mydomain.net">my link</a></p>
+/// "#);
+/// ```
 pub fn push_html_ext<'a, I>(s: &mut String, iter: I, options: RenderingOptions)
 where
     I: Iterator<Item = Event<'a>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,3 +281,11 @@ bitflags::bitflags! {
         const ENABLE_SMART_PUNCTUATION = 1 << 5;
     }
 }
+
+bitflags::bitflags! {
+    /// Option struct containing flags for enabling extra rendering features
+    /// that are not part of the CommonMark spec.
+    pub struct RenderingOptions: u32 {
+        const OPEN_LINK_IN_NEW_TAB = 0b00000001;
+    }
+}


### PR DESCRIPTION
Added options for the renderer, similar to the options for the parser.

Currently there is only one option, to render links that open in a new tab by adding `target="_blank` to the rendered anchor elements.