### PR TITLE
Fix slice error when scanning HTML

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -841,7 +841,7 @@ impl<'input, 'callback> Parser<'input, 'callback> {
             let (span, i) = scan_html_block_inner(
                 // Subtract 1 to include the < character
                 &bytes[(ix - 1)..],
-                Some(&|_bytes| {
+                Some(&|bytes| {
                     let mut line_start = LineStart::new(bytes);
                     let _ = scan_containers(&self.tree, &mut line_start);
                     line_start.bytes_scanned()

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -1067,6 +1067,15 @@ pub(crate) fn scan_html_block_inner(
                     i += eol_bytes;
                     let skipped_bytes = handler(&data[i..]);
 
+                    let data_len = data.len() - i;
+
+                    debug_assert!(
+                        skipped_bytes <= data_len,
+                        "Handler tried to skip too many bytes, fed {}, skipped {}",
+                        data_len,
+                        skipped_bytes
+                    );
+
                     if skipped_bytes > 0 {
                         buffer.extend(&data[last_buf_index..i]);
                         i += skipped_bytes;

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,47 +1,52 @@
 use pulldown_cmark::Parser;
 
+fn parse(md: &str) {
+    let parser = Parser::new(md);
+
+    for _ in parser {}
+}
+
 #[test]
 fn test_wrong_code_block() {
-    let markdown = r##"```
+    parse(
+        r##"```
  * ```
- "##;
-
-    let _ = Parser::new(&markdown);
+ "##,
+    );
 }
 
 #[test]
 fn test_unterminated_link() {
-    let markdown = "[](\\";
-
-    let parser = Parser::new(&markdown);
-    for _ in parser {}
+    parse("[](\\");
 }
 
 #[test]
 fn test_unterminated_autolink() {
-    let _ = Parser::new("<a");
+    parse("<a");
 }
 
 #[test]
 fn test_infinite_loop() {
-    let markdown = "[<!W\n\\\n";
-
-    let parser = Parser::new(&markdown);
-    for _ in parser {}
+    parse("[<!W\n\\\n");
 }
 
 #[test]
 fn test_html_tag() {
-    let markdown = "<script\u{feff}";
+    parse("<script\u{feff}");
+}
 
-    let parser = Parser::new(&markdown);
-    for _ in parser {}
+// all of test_bad_slice_* were found in https://github.com/raphlinus/pulldown-cmark/issues/521
+#[test]
+fn test_bad_slice_a() {
+    parse("><a\n");
 }
 
 #[test]
-fn test_bad_slice() {
-    let markdown = "><a\n";
+fn test_bad_slice_b() {
+    parse("><a a\n");
+}
 
-    let parser = Parser::new(&markdown);
-    for _ in parser {}
+#[test]
+fn test_bad_slice_unicode() {
+    parse("><a a=\n毿>")
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -37,3 +37,11 @@ fn test_html_tag() {
     let parser = Parser::new(&markdown);
     for _ in parser {}
 }
+
+#[test]
+fn test_bad_slice() {
+    let markdown = "><a\n";
+
+    let parser = Parser::new(&markdown);
+    for _ in parser {}
+}

--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -4,10 +4,10 @@
 pub use super::test_markdown_html;
 
 mod footnotes;
-mod table;
-mod regression;
-mod spec;
-mod smart_punct;
-mod gfm_table;
 mod gfm_strikethrough;
+mod gfm_table;
 mod gfm_tasklist;
+mod regression;
+mod smart_punct;
+mod spec;
+mod table;


### PR DESCRIPTION
The core issue here is the one line change in `src/parse.rs`. I'm not entirely sure *why* the closure was using `bytes` from the environment and not the one being passed in, but all the tests pass with this change, so :shrug:.

Looks like that change was added in #400 . 

I've added a debug assert to hopefully make it more clear if this crops up again.