### PR TITLE
Use inline CSS for table cell text alignment

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -195,9 +195,9 @@ where
                     }
                 }
                 match self.table_alignments.get(self.table_cell_index) {
-                    Some(&Alignment::Left) => self.write(" align=\"left\">"),
-                    Some(&Alignment::Center) => self.write(" align=\"center\">"),
-                    Some(&Alignment::Right) => self.write(" align=\"right\">"),
+                    Some(&Alignment::Left) => self.write(" style=\"text-align: left\">"),
+                    Some(&Alignment::Center) => self.write(" style=\"text-align: center\">"),
+                    Some(&Alignment::Right) => self.write(" style=\"text-align: right\">"),
                     _ => self.write(">"),
                 }
             }

--- a/tests/suite/gfm_table.rs
+++ b/tests/suite/gfm_table.rs
@@ -37,14 +37,14 @@ bar | baz
     let expected = r##"<table>
 <thead>
 <tr>
-<th align="center">abc</th>
-<th align="right">defghi</th>
+<th style="text-align: center">abc</th>
+<th style="text-align: right">defghi</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td align="center">bar</td>
-<td align="right">baz</td>
+<td style="text-align: center">bar</td>
+<td style="text-align: right">baz</td>
 </tr>
 </tbody>
 </table>

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -69,8 +69,8 @@ fn regression_test_4() {
     let expected = r##"<table><thead><tr><th>Title A  </th><th>Title B  </th></tr></thead><tbody>
 <tr><td>Content   </td><td>Content   </td></tr>
 </tbody></table>
-<table><thead><tr><th>Title A  </th><th>Title B  </th><th>Title C  </th><th align="right">Title D  </th></tr></thead><tbody>
-<tr><td>Content   </td><td>Content   </td><td>Conent    </td><td align="right">Content   </td></tr>
+<table><thead><tr><th>Title A  </th><th>Title B  </th><th>Title C  </th><th style="text-align: right">Title D  </th></tr></thead><tbody>
+<tr><td>Content   </td><td>Content   </td><td>Conent    </td><td style="text-align: right">Content   </td></tr>
 </tbody></table>
 "##;
 


### PR DESCRIPTION
This seems to be the best solution to https://github.com/raphlinus/pulldown-cmark/issues/533.