### PR TITLE
Fixup clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ By default, the binary is built as well. If you don't want/need it, then build l
 Or put in your `Cargo.toml` file:
 
 ```toml
-pulldown-cmark = { version = "0.8", default-features = false }
+pulldown-cmark = { version = "0.9", default-features = false }
 ```
 
 SIMD accelerated scanners are available for the x64 platform from version 0.5 onwards. To
@@ -139,7 +139,7 @@ enable them, build with simd feature:
 Or add the feature to your project's `Cargo.toml`:
 
 ```toml
-pulldown-cmark = { version = "0.8", default-features = false, features = ["simd"] }
+pulldown-cmark = { version = "0.9", default-features = false, features = ["simd"] }
 ```
 
 ## Authors

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -4,7 +4,7 @@
 use std::cmp::max;
 use std::ops::Range;
 
-use crate::parse::{scan_containers, Allocations, Item, ItemBody, LinkDef};
+use crate::parse::{scan_containers, Allocations, HeadingAttributes, Item, ItemBody, LinkDef};
 use crate::scanners::*;
 use crate::strings::CowStr;
 use crate::tree::{Tree, TreeIndex};
@@ -18,7 +18,7 @@ use unicase::UniCase;
 
 /// Runs the first pass, which resolves the block structure of the document,
 /// and returns the resulting tree.
-pub(crate) fn run_first_pass<'a>(text: &'a str, options: Options) -> (Tree<Item>, Allocations<'a>) {
+pub(crate) fn run_first_pass(text: &str, options: Options) -> (Tree<Item>, Allocations) {
     // This is a very naive heuristic for the number of nodes
     // we'll need.
     let start_capacity = max(128, text.len() / 32);
@@ -1264,7 +1264,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         &mut self,
         header_start: usize,
         header_end: usize,
-    ) -> (usize, Option<(Option<&'a str>, Vec<&'a str>)>) {
+    ) -> (usize, Option<HeadingAttributes<'a>>) {
         if header_start >= header_end {
             return (header_end, None);
         }
@@ -1681,7 +1681,7 @@ fn extract_attribute_block_content_from_header_text(
 /// See also: [`Options::ENABLE_HEADING_ATTRIBUTES`].
 ///
 /// [`Options::ENABLE_HEADING_ATTRIBUTES`]: `crate::Options::ENABLE_HEADING_ATTRIBUTES`
-fn parse_inside_attribute_block(inside_attr_block: &str) -> Option<(Option<&str>, Vec<&str>)> {
+fn parse_inside_attribute_block(inside_attr_block: &str) -> Option<HeadingAttributes> {
     let mut id = None;
     let mut classes = Vec::new();
 
@@ -1702,7 +1702,7 @@ fn parse_inside_attribute_block(inside_attr_block: &str) -> Option<(Option<&str>
         // Return `None` to avoid needless allocation of `(None, Vec::new())`.
         return None;
     }
-    Some((id, classes))
+    Some(HeadingAttributes { id, classes })
 }
 
 #[cfg(all(target_arch = "x86_64", feature = "simd"))]

--- a/src/html.rs
+++ b/src/html.rs
@@ -157,16 +157,16 @@ where
                 write!(&mut self.writer, "{}", level)?;
                 if let Some(id) = id {
                     self.write(" id=\"")?;
-                    escape_html(&mut self.writer, &id)?;
+                    escape_html(&mut self.writer, id)?;
                     self.write("\"")?;
                 }
                 let mut classes = classes.iter();
                 if let Some(class) = classes.next() {
                     self.write(" class=\"")?;
-                    escape_html(&mut self.writer, &class)?;
+                    escape_html(&mut self.writer, class)?;
                     for class in classes {
                         self.write(" ")?;
-                        escape_html(&mut self.writer, &class)?;
+                        escape_html(&mut self.writer, class)?;
                     }
                     self.write("\"")?;
                 }

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -871,7 +871,7 @@ fn scan_attribute(
     if scan_ch(&data[ix..], b'=') == 1 {
         ix += 1;
         ix = scan_whitespace_with_newline_handler(data, ix, newline_handler, buffer, buffer_ix)?;
-        ix = scan_attribute_value(&data, ix, newline_handler, buffer, buffer_ix)?;
+        ix = scan_attribute_value(data, ix, newline_handler, buffer, buffer_ix)?;
     } else if n_whitespace > 0 {
         // Leave whitespace for next attribute.
         ix -= 1;
@@ -1092,7 +1092,7 @@ pub(crate) fn scan_html_block_inner(
                 // No whitespace, which is mandatory.
                 return None;
             }
-            i = scan_attribute(&data, i, newline_handler, &mut buffer, &mut last_buf_index)?;
+            i = scan_attribute(data, i, newline_handler, &mut buffer, &mut last_buf_index)?;
         }
     }
 


### PR DESCRIPTION
And also set the recommended version in the readme to 0.9.