### PR TITLE
Fix index out of bounds error in code span parsing

### DIFF
--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -7,6 +7,17 @@ fn parse(md: &str) {
 }
 
 #[test]
+fn test_lists_inside_code_spans() {
+    parse(
+        r"- `
+x
+**
+  *
+  `",
+    );
+}
+
+#[test]
 fn test_wrong_code_block() {
     parse(
         r##"```


### PR DESCRIPTION
We were laboring under the false assumption that tree siblings have consecutive tree indices. This is only _almost_ always true. In this case it breaks when there is a list (and a _child_ list item, which took the next index) in the code span.

This (partially) fixes https://github.com/raphlinus/pulldown-cmark/issues/561 in that it no longer panics, but it reveals another issue. We render
```md
- `
x
**
  *
  `
```
as
```html
<ul>
  <li>
    <code>
      x ***
    </code>
  </li>
</ul>
```
Note the three consecutive asterisks. There should be a space between the first two and the third. I think it's because we first recognize the final asterisk as a new list, and we therefore break the paragraph and don't insert a break for the newline between the first two asterisks and the last one. In the code parsing code we simply accumulate the text representations of the elements sec, and only add whitespaces for any breaks we replace.

As you may be able to tell above, it's a tricky situation with lots of interactions. It's not immediately clear to me how and where in the code this should be resolved. I think this pull request may be assessed independently, as these changes need to happen regardless of the issue above.