### PR TITLE
Fix smart punctuation

### DIFF
--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -1444,18 +1444,24 @@ fn surgerize_tight_list(tree: &mut Tree<Item>, list_ix: TreeIndex) {
 /// suffix is &s[ix..], which is passed in as an optimization, since taking
 /// a string subslice is O(n).
 fn delim_run_can_open(s: &str, suffix: &str, run_len: usize, ix: usize) -> bool {
-    let next_char = if let Some(c) = suffix.chars().nth(run_len) {
+    let delim = suffix.chars().next().unwrap();
+    let mut iter = suffix.chars().skip(run_len);
+    let next_char = if delim == '"' {
+        iter.skip_while(|c| c.is_whitespace()).next()
+    } else {
+        iter.next()
+    };
+    let next_char = if let Some(c) = next_char {
         c
     } else {
         return false;
     };
-    if next_char.is_whitespace() {
+    if delim != '"' && next_char.is_whitespace() {
         return false;
     }
     if ix == 0 {
         return true;
     }
-    let delim = suffix.chars().next().unwrap();
     if delim == '*' && !is_punctuation(next_char) {
         return true;
     }

--- a/tests/suite/smart_punct.rs
+++ b/tests/suite/smart_punct.rs
@@ -213,3 +213,17 @@ No spaces: “like this”.</p>";
 
     test_markdown_html(original, expected, true);
 }
+
+#[test]
+fn smart_punct_test_18() {
+    let original = r##"Single space at start: ' like this'.
+Single space at end: 'like this '.
+Spaces at start and end: ' like this '.
+No spaces: 'like this'."##;
+    let expected = "<p>Single space at start: ’ like this’. \
+Single space at end: ’like this ’. \
+Spaces at start and end: ’ like this ’. \
+No spaces: ‘like this’.</p>";
+
+    test_markdown_html(original, expected, true);
+}

--- a/tests/suite/smart_punct.rs
+++ b/tests/suite/smart_punct.rs
@@ -199,3 +199,17 @@ fn smart_punct_test_16() {
 
     test_markdown_html(original, expected, true);
 }
+
+#[test]
+fn smart_punct_test_17() {
+    let original = r##"Single space at start: " like this".
+Single space at end: "like this ".
+Spaces at start and end: " like this ".
+No spaces: "like this"."##;
+    let expected = "<p>Single space at start: “ like this”. \
+Single space at end: “like this “. \
+Spaces at start and end: “ like this “. \
+No spaces: “like this”.</p>";
+
+    test_markdown_html(original, expected, true);
+}


### PR DESCRIPTION
As reported on rustdoc: https://github.com/rust-lang/rust/issues/92578, the smart punctuation was incorrect in case the opening quote isn't followed right away by a letter. Based on the [commonmark spec](https://spec.commonmark.org/dingus/?text=Single%20space%20at%20start%3A%20%22%20like%20this%22.%0ASingle%20space%20at%20end%3A%20%22like%20this%20%22.%0ASpaces%20at%20start%20and%20end%3A%20%22%20like%20this%20%22.%0ANo%20spaces%3A%20%22like%20this%22.&smart=1), it's fine. Only the closing quote matters as it seems.

I didn't write a specialized version but I can if you prefer to handle double quotes on their own?