### PR TITLE
Add examples for newcomer developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ Further, it optionally supports parsing footnotes,
 
 Rustc 1.46 or newer is required to build the crate.
 
+## Example
+
+Example usage:
+
+```rust
+// Create parser with example Markdown text.
+let markdown_input = "hello world";
+let parser = pulldown_cmark::Parser::new(markdown_input);
+
+// Write to a new String buffer.
+let mut html_output = String::new();
+pulldown_cmark::html::push_html(&mut html_output, parser);
+assert_eq!(&html_output, "<p>hello world</p>\n");
+```
+
 ## Why a pull parser?
 
 There are many parsers for Markdown and its variants, but to my knowledge none

--- a/examples/parser-map-event-print.rs
+++ b/examples/parser-map-event-print.rs
@@ -1,0 +1,31 @@
+use pulldown_cmark::{Event, Parser, html};
+
+fn main() {
+    let markdown_input = "# Example Heading\nExample paragraph with **lorem** _ipsum_ text.";
+    println!("\nParsing the following markdown string:\n{}\n", markdown_input);
+
+    // Set up the parser. We can treat is as any other iterator. 
+    // For each event, we print its details, such as the tag or string.
+    // This filter simply returns the same event without any changes;
+    // you can compare the `event-filter` example which alters the output.
+    let parser = Parser::new(markdown_input)
+    .map(|event| {
+        match &event {
+            Event::Start(tag) => println!("Start: {:?}", tag),
+            Event::End(tag) => println!("End: {:?}", tag),
+            Event::Html(s) => println!("Html: {:?}", s),
+            Event::Text(s) => println!("Text: {:?}", s),
+            Event::Code(s) => println!("Code: {:?}", s),
+            Event::FootnoteReference(s) => println!("FootnoteReference: {:?}", s),
+            Event::TaskListMarker(b) => println!("TaskListMarker: {:?}", b),
+            Event::SoftBreak => println!("SoftBreak"),
+            Event::HardBreak => println!("HardBreak"),
+            Event::Rule => println!("Rule"),
+        };
+        event
+    });
+
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+    println!("\nHTML output:\n{}\n", &html_output);
+}

--- a/examples/parser-map-tag-print.rs
+++ b/examples/parser-map-tag-print.rs
@@ -1,0 +1,73 @@
+use pulldown_cmark::{Event, Options, Parser, Tag};
+
+fn main() {
+    let markdown_input = concat!(
+        "# My Heading\n",
+        "\n",
+        "My paragraph.\n",
+        "\n",
+        "* a\n",
+        "* b\n",
+        "* c\n",
+        "\n",
+        "1. d\n",
+        "2. e\n",
+        "3. f\n",
+        "\n",
+        "> my block quote\n",
+        "\n",
+        "```\n",
+        "my code block\n",
+        "```\n",
+        "\n",       
+        "*emphasis*\n",
+        "**strong**\n",
+        "~~strikethrough~~\n",
+        "[My Link](http://example.com)\n",
+        "![My Image](http://example.com/image.jpg)\n",
+        "\n",
+        "| a | b |\n",
+        "| - | - |\n",
+        "| c | d |\n",
+        "\n",
+        "hello[^1]\n",
+        "[^1]: my footnote\n",
+    );
+    println!("\nParsing the following markdown string:\n{}\n", markdown_input);
+
+    // Set up the parser. We can treat is as any other iterator. 
+    // For each event, we print its details, such as the tag or string.
+    // This filter simply returns the same event without any changes;
+    // you can compare the `event-filter` example which alters the output.
+    let parser = Parser::new_ext(markdown_input, Options::all())
+    .map(|event| {
+        match &event {
+            Event::Start(tag) => {
+                match tag {
+                    Tag::Heading(heading_level, fragment_identifier, class_list) => println!("Heading heading_level: {} fragment identifier: {:?} classes: {:?}", heading_level, fragment_identifier, class_list),
+                    Tag::Paragraph => println!("Paragraph"),                       
+                    Tag::List(ordered_list_first_item_number) => println!("List ordered_list_first_item_number: {:?}", ordered_list_first_item_number),
+                    Tag::Item => println!("Item (this is a list item)"),
+                    Tag::Emphasis => println!("Emphasis (this is a span tag)"),
+                    Tag::Strong => println!("Strong (this is a span tag)"),
+                    Tag::Strikethrough => println!("Strikethrough (this is a span tag)"),
+                    Tag::BlockQuote => println!("BlockQuote"),
+                    Tag::CodeBlock(code_block_kind) => println!("CodeBlock code_block_kind: {:?}", code_block_kind),
+                    Tag::Link(link_type, url, title) => println!("Link link_type: {:?} url: {} title: {}", link_type, url, title),
+                    Tag::Image(link_type, url, title) => println!("Image link_type: {:?} url: {} title: {}", link_type, url, title),
+                    Tag::Table(column_text_alignment_list) => println!("Table column_text_alignment_list: {:?}", column_text_alignment_list),
+                    Tag::TableHead => println!("TableHead (contains TableRow tags"),
+                    Tag::TableRow => println!("TableRow (contains TableCell tags)"),
+                    Tag::TableCell => println!("TableCell (contains inline tags)"),
+                    Tag::FootnoteDefinition(label) => println!("FootnoteDefinition label: {}", label),
+                }
+            },
+            _ => ()
+        };
+        event
+    });
+   
+    let mut html_output = String::new();
+    pulldown_cmark::html::push_html(&mut html_output, parser);
+    println!("\nHTML output:\n{}\n", &html_output);
+}


### PR DESCRIPTION
The purpose of this commit is to help newcomers i.e. developers who are discovering pulldown-cmark for the first time.

This commit has 3 independent items and could easily be split into multiple commits if that's more suitable:

1. A new example usage code block for "hello world" in the README.

2. A new program "examples/parser-map-event-print" that uses a parser map in order to print events. This code is similar to the existing "examples/event-filter", plus has a focus on simple printing rather than on content rewriting.

3. A new program "examples/parser-map-tag-print" that uses a parser map in order to print tags. This code is similar to the existing "examples/event-filter", plus has a focus on start tags including extensions e.g. tables.