### PR TITLE
Add "no-backline" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ bincode = "1.3.1"
 default = ["getopts"]
 gen-tests = []
 simd = []
+no-backline = []


### PR DESCRIPTION
This is part of an effort to reduce the number of unneeded characters in the generated HTML. So using this feature when generating the `std` gave this result:

```
Using `du -s doc/std/`:

before: 105860
after: 105812

Using `wc -c std/index.html`:

before: 62859
after: 62631
```

So surprisingly, the number of characters seems to be quite high on a given file, but the impact on the documentation seems quite small.

So what do you think of this feature? Would you be interested into it? It diverges from the commonmark spec, hence why I suggest to add it as a feature and not a parameter.