### PR TITLE
Bump MSRV in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Further, it optionally supports parsing footnotes,
 [Github flavored task lists](https://github.github.com/gfm/#task-list-items-extension-) and
 [strikethrough](https://github.github.com/gfm/#strikethrough-extension-).
 
-Rustc 1.46 or newer is required to build the crate.
+Rustc 1.56 or newer is required to build the crate.
 
 ## Why a pull parser?
 


### PR DESCRIPTION
Since this was increased in https://github.com/raphlinus/pulldown-cmark/commit/f30d7201ce078af72d305c3e6287215ae2679154.