### PR TITLE
Remove unnecessary default feature `getopts`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,6 @@ serde_json = "1.0.61"
 bincode = "1.3.1"
 
 [features]
-default = ["getopts"]
+default = []
 gen-tests = []
 simd = []


### PR DESCRIPTION
`getopts` crate is only used for executable, but added to default features. This can reduce number of dependencies when this crate is installed as lib.