### PR TITLE
Interrupt paragraph continuing when the line is footnote definition

### DIFF
--- a/specs/footnotes.txt
+++ b/specs/footnotes.txt
@@ -105,17 +105,17 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
 ````````````````````````````````
 
 
-As a special exception, footnotes cannot be nested directly inside each other.
+As a special exception, footnotes cannot be nested inside each other.
 
 ```````````````````````````````` example
 Nested footnotes are considered poor style. [^a] [^xkcd]
 
 [^a]: This does not mean that footnotes cannot reference each other. [^b]
 
-[^b]: This means that a footnote definition cannot be directly inside another footnote definition.
-> This means that a footnote cannot be directly inside another footnote's body. [^e]
+[^b]: This means that a footnote definition cannot be inside another footnote definition.
+> This means that a footnote cannot be inside another footnote's body. [^e]
 >
-> [^e]: They can, however, be inside anything else.
+> [^e]: They also cannot be inside anything else.
 
 [^xkcd]: [The other kind of nested footnote is, however, considered poor style.](https://xkcd.com/1208/)
 .
@@ -124,30 +124,34 @@ Nested footnotes are considered poor style. [^a] [^xkcd]
 <p>This does not mean that footnotes cannot reference each other. <sup class="footnote-reference"><a href="#b">3</a></sup></p>
 </div>
 <div class="footnote-definition" id="b"><sup class="footnote-definition-label">3</sup>
-<p>This means that a footnote definition cannot be directly inside another footnote definition.</p>
+<p>This means that a footnote definition cannot be inside another footnote definition.</p>
+</div>
 <blockquote>
-<p>This means that a footnote cannot be directly inside another footnote's body. <sup class="footnote-reference"><a href="#e">4</a></sup></p>
+<p>This means that a footnote cannot be inside another footnote's body. <sup class="footnote-reference"><a href="#e">4</a></sup></p>
 <div class="footnote-definition" id="e"><sup class="footnote-definition-label">4</sup>
-<p>They can, however, be inside anything else.</p>
+<p>They also cannot be inside anything else.</p>
 </div>
 </blockquote>
-</div>
 <div class="footnote-definition" id="xkcd"><sup class="footnote-definition-label">2</sup>
 <p><a href="https://xkcd.com/1208/">The other kind of nested footnote is, however, considered poor style.</a></p>
 </div>
 ````````````````````````````````
 
-They do need one line between each other.
+They don't need one line between each other.
 
 ```````````````````````````````` example
 [^Doh] Ray Me Fa So La Te Do! [^1]
 
-[^Doh]: I know. Wrong Doe. And it won't render right.
+This line does not prevent the following footnote definitions.
+[^Doh]: I know. Doe. And it will render right.
 [^1]: Common for people practicing music.
 .
 <p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p>
+<p>This line does not prevent the following footnote definitions.</p>
 <div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup>
-<p>I know. Wrong Doe. And it won't render right.
-<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p>
+<p>I know. Doe. And it will render right.</p>
+</div>
+<div class="footnote-definition" id="1"><sup class="footnote-definition-label">2</sup>
+<p>Common for people practicing music.</p>
 </div>
 ````````````````````````````````

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -1310,6 +1310,21 @@ pub(crate) fn scan_inline_html_processing(
     None
 }
 
+pub(crate) fn scan_footnote_refdef_label(bytes: &[u8]) -> Option<usize> {
+    if !bytes.starts_with(b"[^") {
+        return None;
+    }
+    let mut prev = bytes[1];
+    for (i, b) in bytes[2..].iter().copied().enumerate() {
+        match b {
+            b'\n' | b'\r' => break,
+            b':' if prev == b']' => return Some(i + 2),
+            _ => prev = b,
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/tests/suite/footnotes.rs
+++ b/tests/suite/footnotes.rs
@@ -119,10 +119,10 @@ fn footnotes_test_7() {
 
 [^a]: This does not mean that footnotes cannot reference each other. [^b]
 
-[^b]: This means that a footnote definition cannot be directly inside another footnote definition.
-> This means that a footnote cannot be directly inside another footnote's body. [^e]
+[^b]: This means that a footnote definition cannot be inside another footnote definition.
+> This means that a footnote cannot be inside another footnote's body. [^e]
 >
-> [^e]: They can, however, be inside anything else.
+> [^e]: They also cannot be inside anything else.
 
 [^xkcd]: [The other kind of nested footnote is, however, considered poor style.](https://xkcd.com/1208/)
 "##;
@@ -131,14 +131,14 @@ fn footnotes_test_7() {
 <p>This does not mean that footnotes cannot reference each other. <sup class="footnote-reference"><a href="#b">3</a></sup></p>
 </div>
 <div class="footnote-definition" id="b"><sup class="footnote-definition-label">3</sup>
-<p>This means that a footnote definition cannot be directly inside another footnote definition.</p>
+<p>This means that a footnote definition cannot be inside another footnote definition.</p>
+</div>
 <blockquote>
-<p>This means that a footnote cannot be directly inside another footnote's body. <sup class="footnote-reference"><a href="#e">4</a></sup></p>
+<p>This means that a footnote cannot be inside another footnote's body. <sup class="footnote-reference"><a href="#e">4</a></sup></p>
 <div class="footnote-definition" id="e"><sup class="footnote-definition-label">4</sup>
-<p>They can, however, be inside anything else.</p>
+<p>They also cannot be inside anything else.</p>
 </div>
 </blockquote>
-</div>
 <div class="footnote-definition" id="xkcd"><sup class="footnote-definition-label">2</sup>
 <p><a href="https://xkcd.com/1208/">The other kind of nested footnote is, however, considered poor style.</a></p>
 </div>
@@ -151,13 +151,17 @@ fn footnotes_test_7() {
 fn footnotes_test_8() {
     let original = r##"[^Doh] Ray Me Fa So La Te Do! [^1]
 
-[^Doh]: I know. Wrong Doe. And it won't render right.
+This line does not prevent the following footnote definitions.
+[^Doh]: I know. Doe. And it will render right.
 [^1]: Common for people practicing music.
 "##;
     let expected = r##"<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p>
+<p>This line does not prevent the following footnote definitions.</p>
 <div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup>
-<p>I know. Wrong Doe. And it won't render right.
-<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p>
+<p>I know. Doe. And it will render right.</p>
+</div>
+<div class="footnote-definition" id="1"><sup class="footnote-definition-label">2</sup>
+<p>Common for people practicing music.</p>
 </div>
 "##;
 


### PR DESCRIPTION
Fix #618

With this PR, a footnote definition no longer requires a blank line before it.

```markdown
This is ok
[^1]: Previous line is not blank but it's ok
[^2]: This line is also ok
```

This PR also flattens footnote definitions. For example,

```markdown
[^a]: outer
> [^b]: They also cannot be inside anything else.
```

is parsed into the following HTML with current master branch:

```html
<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
<p>outer</p>
<blockquote>
<p><sup class="footnote-reference"><a href="#b">2</a></sup>: They also cannot be inside anything else.</p>
</blockquote>
</div>
```

But with this PR, it is parsed into the following HTML:

```html
<div class="footnote-definition" id="a"><sup class="footnote-definition-label">1</sup>
<p>outer</p>
</div>
<blockquote>
<p><sup class="footnote-reference"><a href="#b">2</a></sup>: They also cannot be inside anything else.</p>
</blockquote>
```

I'm not sure this is correct behavior, but GitHub's Markdown renderer flattens the definitions as follows:

Test [^a] [^b]

[^a]: outer
> [^b]: They also cannot be inside anything else.