### PR TITLE
Fix text wrapped in a matching pair of one tildes is not parsed as strikethrough

### DIFF
--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -562,7 +562,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                     let count = 1 + scan_ch_repeat(&string_suffix.as_bytes()[1..], c);
                     let can_open = delim_run_can_open(self.text, string_suffix, count, ix);
                     let can_close = delim_run_can_close(self.text, string_suffix, count, ix);
-                    let is_valid_seq = c != b'~' || count == 2;
+                    let is_valid_seq = c != b'~' || count <= 2;
 
                     if (can_open || can_close) && is_valid_seq {
                         self.tree.append_text(begin_text, ix);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -566,12 +566,17 @@ impl<'input, 'callback> Parser<'input, 'callback> {
 
                             // work from the inside out
                             while start > el.start + el.count - match_count {
-                                let (inc, ty) = if c == b'~' {
-                                    (2, ItemBody::Strikethrough)
-                                } else if start > el.start + el.count - match_count + 1 {
-                                    (2, ItemBody::Strong)
+                                let inc = if start > el.start + el.count - match_count + 1 {
+                                    2
                                 } else {
-                                    (1, ItemBody::Emphasis)
+                                    1
+                                };
+                                let ty = if c == b'~' {
+                                    ItemBody::Strikethrough
+                                } else if inc == 2 {
+                                    ItemBody::Strong
+                                } else {
+                                    ItemBody::Emphasis
                                 };
 
                                 let root = start - inc;

--- a/tests/suite/gfm_strikethrough.rs
+++ b/tests/suite/gfm_strikethrough.rs
@@ -5,9 +5,9 @@ use super::test_markdown_html;
 
 #[test]
 fn gfm_strikethrough_test_1() {
-    let original = r##"~~Hi~~ Hello, world!
+    let original = r##"~~Hi~~ Hello, ~there~ world!
 "##;
-    let expected = r##"<p><del>Hi</del> Hello, world!</p>
+    let expected = r##"<p><del>Hi</del> Hello, <del>there</del> world!</p>
 "##;
 
     test_markdown_html(original, expected, false);
@@ -21,6 +21,16 @@ new paragraph~~.
 "##;
     let expected = r##"<p>This ~~has a</p>
 <p>new paragraph~~.</p>
+"##;
+
+    test_markdown_html(original, expected, false);
+}
+
+#[test]
+fn gfm_strikethrough_test_3() {
+    let original = r##"This will ~~~not~~~ strike.
+"##;
+    let expected = r##"<p>This will ~~~not~~~ strike.</p>
 "##;
 
     test_markdown_html(original, expected, false);

--- a/third_party/GitHub/gfm_strikethrough.txt
+++ b/third_party/GitHub/gfm_strikethrough.txt
@@ -6,12 +6,12 @@
 GFM enables the `strikethrough` extension, where an additional emphasis type is
 available.
 
-Strikethrough text is any text wrapped in two tildes (`~`).
+Strikethrough text is any text wrapped in a matching pair of one or two tildes (`~`).
 
 ```````````````````````````````` example
-~~Hi~~ Hello, world!
+~~Hi~~ Hello, ~there~ world!
 .
-<p><del>Hi</del> Hello, world!</p>
+<p><del>Hi</del> Hello, <del>there</del> world!</p>
 ````````````````````````````````
 
 As with regular emphasis delimiters, a new paragraph will cause strikethrough
@@ -24,4 +24,12 @@ new paragraph~~.
 .
 <p>This ~~has a</p>
 <p>new paragraph~~.</p>
+````````````````````````````````
+
+Three or more tildes do not create a strikethrough:
+
+```````````````````````````````` example
+This will ~~~not~~~ strike.
+.
+<p>This will ~~~not~~~ strike.</p>
 ````````````````````````````````


### PR DESCRIPTION
Fix #620 