### PR TITLE
make easier for developers to produce alternate HTML for specific events/tags

### DIFF
--- a/examples/alt-html.rs
+++ b/examples/alt-html.rs
@@ -1,0 +1,55 @@
+use pulldown_cmark::{Event, LinkType, Parser, Tag, html::HtmlWriter};
+use pulldown_cmark::escape::{escape_href, escape_html};
+use pulldown_cmark::CowStr;
+use std::io;
+use std::path::Path;
+
+fn is_audio_file(url: &CowStr) -> bool {
+    let audio_format = ["mp3", "mp4", "m4a", "wav", "ogg"];
+    let path = Path::new(url.as_ref());
+    if let Some(ext_osstr) = path.extension() {
+        let extension = ext_osstr.to_string_lossy().to_lowercase();
+        if audio_format.contains(&extension.as_str()) {
+            return true
+        }
+    }
+    false
+}
+
+fn main() -> io::Result<()> {
+    let markdown_input = r#"
+# Example Heading
+Example paragraph with **lorem** _ipsum_ text.
+Normal link: [example](https://example.com)
+Audio link: [](https://file-examples.com/storage/feeb72b10363daaeba4c0c9/2017/11/file_example_MP3_700KB.mp3)
+"#;
+println!("\nParsing the following markdown string:\n{}\n", markdown_input);
+
+    let parser = Parser::new(markdown_input);
+    let mut html_output = String::new();
+    let mut html = HtmlWriter::new(parser, &mut html_output);
+    
+    while let Some(event) = html.iter.next() {
+        match &event {
+            Event::Start(Tag::Link(LinkType::Inline, dest, title)) => {
+                if is_audio_file(dest) {
+                    html.write("<a href=\"")?;
+                    escape_href(&mut html.writer, &dest)?;
+                    html.write("\" title=\"")?;
+                    if !title.is_empty() {
+                        escape_html(&mut html.writer, &title)?;
+                    } else {
+                        html.write("Play Audio")?;
+                    }
+                    html.write("\" class=\"audio\">")?;
+                } else {
+                    html.render_event(event)?
+                }
+            },
+            _ => html.render_event(event)?,
+        };
+    };
+
+    println!("\nHTML output:\n{}\n", &html_output);
+    Ok(())
+}

--- a/src/html.rs
+++ b/src/html.rs
@@ -85,55 +85,61 @@ where
 
     fn run(mut self) -> io::Result<()> {
         while let Some(event) = self.iter.next() {
-            match event {
-                Start(tag) => {
-                    self.start_tag(tag)?;
-                }
-                End(tag) => {
-                    self.end_tag(tag)?;
-                }
-                Text(text) => {
-                    escape_html(&mut self.writer, &text)?;
-                    self.end_newline = text.ends_with('\n');
-                }
-                Code(text) => {
-                    self.write("<code>")?;
-                    escape_html(&mut self.writer, &text)?;
-                    self.write("</code>")?;
-                }
-                Html(html) => {
-                    self.write(&html)?;
-                }
-                SoftBreak => {
-                    self.write_newline()?;
-                }
-                HardBreak => {
-                    self.write("<br />\n")?;
-                }
-                Rule => {
-                    if self.end_newline {
-                        self.write("<hr />\n")?;
-                    } else {
-                        self.write("\n<hr />\n")?;
-                    }
-                }
-                FootnoteReference(name) => {
-                    let len = self.numbers.len() + 1;
-                    self.write("<sup class=\"footnote-reference\"><a href=\"#")?;
-                    escape_html(&mut self.writer, &name)?;
-                    self.write("\">")?;
-                    let number = *self.numbers.entry(name).or_insert(len);
-                    write!(&mut self.writer, "{}", number)?;
-                    self.write("</a></sup>")?;
-                }
-                TaskListMarker(true) => {
-                    self.write("<input disabled=\"\" type=\"checkbox\" checked=\"\"/>\n")?;
-                }
-                TaskListMarker(false) => {
-                    self.write("<input disabled=\"\" type=\"checkbox\"/>\n")?;
+            self.render_event(event)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn render_event(&mut self, event: Event<'a>) -> io::Result<()> {
+        match event {
+            Start(tag) => {
+                self.start_tag(tag)?;
+            }
+            End(tag) => {
+                self.end_tag(tag)?;
+            }
+            Text(text) => {
+                escape_html(&mut self.writer, &text)?;
+                self.end_newline = text.ends_with('\n');
+            }
+            Code(text) => {
+                self.write("<code>")?;
+                escape_html(&mut self.writer, &text)?;
+                self.write("</code>")?;
+            }
+            Html(html) => {
+                self.write(&html)?;
+            }
+            SoftBreak => {
+                self.write_newline()?;
+            }
+            HardBreak => {
+                self.write("<br />\n")?;
+            }
+            Rule => {
+                if self.end_newline {
+                    self.write("<hr />\n")?;
+                } else {
+                    self.write("\n<hr />\n")?;
                 }
             }
-        }
+            FootnoteReference(name) => {
+                let len = self.numbers.len() + 1;
+                self.write("<sup class=\"footnote-reference\"><a href=\"#")?;
+                escape_html(&mut self.writer, &name)?;
+                self.write("\">")?;
+                let number = *self.numbers.entry(name).or_insert(len);
+                write!(&mut self.writer, "{}", number)?;
+                self.write("</a></sup>")?;
+            }
+            TaskListMarker(true) => {
+                self.write("<input disabled=\"\" type=\"checkbox\" checked=\"\"/>\n")?;
+            }
+            TaskListMarker(false) => {
+                self.write("<input disabled=\"\" type=\"checkbox\"/>\n")?;
+            }
+        }      
         Ok(())
     }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -28,17 +28,19 @@ use crate::strings::CowStr;
 use crate::Event::*;
 use crate::{Alignment, CodeBlockKind, Event, LinkType, Tag};
 
+#[derive(Debug)]
 enum TableState {
     Head,
     Body,
 }
 
-struct HtmlWriter<'a, I, W> {
+#[derive(Debug)]
+pub struct HtmlWriter<'a, I, W> {
     /// Iterator supplying events.
-    iter: I,
+    pub iter: I,
 
     /// Writer to write to.
-    writer: W,
+    pub writer: W,
 
     /// Whether or not the last write wrote a newline.
     end_newline: bool,
@@ -54,7 +56,7 @@ where
     I: Iterator<Item = Event<'a>>,
     W: StrWrite,
 {
-    fn new(iter: I, writer: W) -> Self {
+    pub fn new(iter: I, writer: W) -> Self {
         Self {
             iter,
             writer,
@@ -74,7 +76,7 @@ where
 
     /// Writes a buffer, and tracks whether or not a newline was written.
     #[inline]
-    fn write(&mut self, s: &str) -> io::Result<()> {
+    pub fn write(&mut self, s: &str) -> io::Result<()> {
         self.writer.write_str(s)?;
 
         if !s.is_empty() {
@@ -91,7 +93,7 @@ where
     }
 
     #[inline]
-    fn render_event(&mut self, event: Event<'a>) -> io::Result<()> {
+    pub fn render_event(&mut self, event: Event<'a>) -> io::Result<()> {
         match event {
             Start(tag) => {
                 self.start_tag(tag)?;


### PR DESCRIPTION
This is a possible approach to addressing https://github.com/raphlinus/pulldown-cmark/issues/584
It could also allow for developers to experiment with CommonMark extension that conform to standard syntax.  

It involves making `HTMLWriter` public and refactoring to create a public `render_event` function.  I'm curious if the project maintainers see this as something that the library could support, and if so, whether this approach is reasonable.  

Happy to work on it further, with feedback. Or please let me know if this is *not* something you ever want to pursue, in which case, I'll consider a different library or possibly maintain my own fork for my use case.