### PR TITLE
add option to parse single * as strong like in slack

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,5 +286,6 @@ bitflags::bitflags! {
         /// with the content `text`, ID `id`, and classes `class1` and `class2`.
         /// Note that attributes (ID and classes) should be space-separated.
         const ENABLE_HEADING_ATTRIBUTES = 1 << 6;
+        const ENABLE_SINGLE_EMPHASIS_IS_STRONG = 1 << 7;
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -573,7 +573,11 @@ impl<'input, 'callback> Parser<'input, 'callback> {
                                 };
                                 let ty = if c == b'~' {
                                     ItemBody::Strikethrough
-                                } else if inc == 2 {
+                                } else if inc == 2
+                                    || self
+                                        .options
+                                        .contains(Options::ENABLE_SINGLE_EMPHASIS_IS_STRONG)
+                                {
                                     ItemBody::Strong
                                 } else {
                                     ItemBody::Emphasis

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -574,9 +574,10 @@ impl<'input, 'callback> Parser<'input, 'callback> {
                                 let ty = if c == b'~' {
                                     ItemBody::Strikethrough
                                 } else if inc == 2
-                                    || self
-                                        .options
-                                        .contains(Options::ENABLE_SINGLE_EMPHASIS_IS_STRONG)
+                                    || (c == b'*'
+                                        && self
+                                            .options
+                                            .contains(Options::ENABLE_SINGLE_EMPHASIS_IS_STRONG))
                                 {
                                     ItemBody::Strong
                                 } else {

--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -9,6 +9,7 @@ mod gfm_table;
 mod gfm_tasklist;
 mod heading_attrs;
 mod regression;
+mod slack;
 mod smart_punct;
 mod spec;
 mod table;

--- a/tests/suite/slack.rs
+++ b/tests/suite/slack.rs
@@ -1,0 +1,27 @@
+use pulldown_cmark::{Options, Parser};
+
+use crate::normalize_html;
+
+use super::test_markdown_html;
+
+#[test]
+fn default_is_emphasis() {
+    let original = "*hi*";
+    let expected = "<p><em>hi</em></p>";
+
+    test_markdown_html(original, expected, false);
+}
+
+#[test]
+fn with_option_is_strong() {
+    let input = "*hi*";
+    let output = "<p><strong>hi</strong></p>";
+
+    let mut s = String::new();
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_SINGLE_EMPHASIS_IS_STRONG);
+    let p = Parser::new_ext(input, opts);
+    pulldown_cmark::html::push_html(&mut s, p);
+
+    assert_eq!(normalize_html(output), normalize_html(&s));
+}

--- a/tests/suite/slack.rs
+++ b/tests/suite/slack.rs
@@ -2,7 +2,20 @@ use pulldown_cmark::{Options, Parser};
 
 use crate::normalize_html;
 
-use super::test_markdown_html;
+pub fn test_markdown_html(input: &str, output: &str, slack_dialect: bool) {
+    let mut s = String::new();
+
+    let mut opts = Options::empty();
+
+    if slack_dialect {
+        opts.insert(Options::ENABLE_SINGLE_EMPHASIS_IS_STRONG);
+    }
+
+    let p = Parser::new_ext(input, opts);
+    pulldown_cmark::html::push_html(&mut s, p);
+
+    assert_eq!(normalize_html(output), normalize_html(&s));
+}
 
 #[test]
 fn default_is_emphasis() {
@@ -14,14 +27,17 @@ fn default_is_emphasis() {
 
 #[test]
 fn with_option_is_strong() {
-    let input = "*hi*";
-    let output = "<p><strong>hi</strong></p>";
+    let original = "*hi*";
+    let expected = "<p><strong>hi</strong></p>";
 
-    let mut s = String::new();
-    let mut opts = Options::empty();
-    opts.insert(Options::ENABLE_SINGLE_EMPHASIS_IS_STRONG);
-    let p = Parser::new_ext(input, opts);
-    pulldown_cmark::html::push_html(&mut s, p);
+    test_markdown_html(original, expected, true);
+}
 
-    assert_eq!(normalize_html(output), normalize_html(&s));
+#[test]
+fn underline_with_option_is_emphasis() {
+    let original = "_hi_";
+    let expected = "<p><em>hi</em></p>";
+
+    test_markdown_html(original, expected, true);
+    test_markdown_html(original, expected, false);
 }


### PR DESCRIPTION
In slack single `*` mean `<strong>`, see https://slack.com/help/articles/202288908-Format-your-messages#markup

this PD adds an option that when set will emit single `*` emphasis as strong.