### PR TITLE
feat!: allow custom headings attributes with optional value. Fixes #634

### DIFF
--- a/examples/parser-map-tag-print.rs
+++ b/examples/parser-map-tag-print.rs
@@ -19,7 +19,7 @@ fn main() {
         "```\n",
         "my code block\n",
         "```\n",
-        "\n",       
+        "\n",
         "*emphasis*\n",
         "**strong**\n",
         "~~strikethrough~~\n",
@@ -33,40 +33,62 @@ fn main() {
         "hello[^1]\n",
         "[^1]: my footnote\n",
     );
-    println!("\nParsing the following markdown string:\n{}\n", markdown_input);
+    println!(
+        "\nParsing the following markdown string:\n{}\n",
+        markdown_input
+    );
 
-    // Set up the parser. We can treat is as any other iterator. 
+    // Set up the parser. We can treat is as any other iterator.
     // For each event, we print its details, such as the tag or string.
     // This filter simply returns the same event without any changes;
     // you can compare the `event-filter` example which alters the output.
-    let parser = Parser::new_ext(markdown_input, Options::all())
-    .map(|event| {
+    let parser = Parser::new_ext(markdown_input, Options::all()).map(|event| {
         match &event {
-            Event::Start(tag) => {
-                match tag {
-                    Tag::Heading(heading_level, fragment_identifier, class_list) => println!("Heading heading_level: {} fragment identifier: {:?} classes: {:?}", heading_level, fragment_identifier, class_list),
-                    Tag::Paragraph => println!("Paragraph"),                       
-                    Tag::List(ordered_list_first_item_number) => println!("List ordered_list_first_item_number: {:?}", ordered_list_first_item_number),
-                    Tag::Item => println!("Item (this is a list item)"),
-                    Tag::Emphasis => println!("Emphasis (this is a span tag)"),
-                    Tag::Strong => println!("Strong (this is a span tag)"),
-                    Tag::Strikethrough => println!("Strikethrough (this is a span tag)"),
-                    Tag::BlockQuote => println!("BlockQuote"),
-                    Tag::CodeBlock(code_block_kind) => println!("CodeBlock code_block_kind: {:?}", code_block_kind),
-                    Tag::Link(link_type, url, title) => println!("Link link_type: {:?} url: {} title: {}", link_type, url, title),
-                    Tag::Image(link_type, url, title) => println!("Image link_type: {:?} url: {} title: {}", link_type, url, title),
-                    Tag::Table(column_text_alignment_list) => println!("Table column_text_alignment_list: {:?}", column_text_alignment_list),
-                    Tag::TableHead => println!("TableHead (contains TableRow tags"),
-                    Tag::TableRow => println!("TableRow (contains TableCell tags)"),
-                    Tag::TableCell => println!("TableCell (contains inline tags)"),
-                    Tag::FootnoteDefinition(label) => println!("FootnoteDefinition label: {}", label),
+            Event::Start(tag) => match tag {
+                Tag::Heading {
+                    level,
+                    id,
+                    classes,
+                    attrs,
+                } => println!(
+                    "Heading heading_level: {} fragment identifier: {:?} classes: {:?} attrs: {:?}",
+                    level, id, classes, attrs
+                ),
+                Tag::Paragraph => println!("Paragraph"),
+                Tag::List(ordered_list_first_item_number) => println!(
+                    "List ordered_list_first_item_number: {:?}",
+                    ordered_list_first_item_number
+                ),
+                Tag::Item => println!("Item (this is a list item)"),
+                Tag::Emphasis => println!("Emphasis (this is a span tag)"),
+                Tag::Strong => println!("Strong (this is a span tag)"),
+                Tag::Strikethrough => println!("Strikethrough (this is a span tag)"),
+                Tag::BlockQuote => println!("BlockQuote"),
+                Tag::CodeBlock(code_block_kind) => {
+                    println!("CodeBlock code_block_kind: {:?}", code_block_kind)
                 }
+                Tag::Link(link_type, url, title) => println!(
+                    "Link link_type: {:?} url: {} title: {}",
+                    link_type, url, title
+                ),
+                Tag::Image(link_type, url, title) => println!(
+                    "Image link_type: {:?} url: {} title: {}",
+                    link_type, url, title
+                ),
+                Tag::Table(column_text_alignment_list) => println!(
+                    "Table column_text_alignment_list: {:?}",
+                    column_text_alignment_list
+                ),
+                Tag::TableHead => println!("TableHead (contains TableRow tags"),
+                Tag::TableRow => println!("TableRow (contains TableCell tags)"),
+                Tag::TableCell => println!("TableCell (contains inline tags)"),
+                Tag::FootnoteDefinition(label) => println!("FootnoteDefinition label: {}", label),
             },
-            _ => ()
+            _ => (),
         };
         event
     });
-   
+
     let mut html_output = String::new();
     pulldown_cmark::html::push_html(&mut html_output, parser);
     println!("\nHTML output:\n{}\n", &html_output);

--- a/specs/heading_attrs.txt
+++ b/specs/heading_attrs.txt
@@ -15,7 +15,8 @@ Strictly speaking, attribute blocks satisfies the conditions below:
 
 Attributes are separated by ASCII non-newline whitespaces.
 An ID attribute is specified as `#id-fragment-here`, and a class attribute is
-specified as `.class-here`.
+specified as `.class-here`. Custom attributes has not a prefix and can optionally
+have a value (`myattr`, `myattr=myvalue`).
 
 Basic usage with setext headings:
 
@@ -24,12 +25,15 @@ with the ID {#myh1}
 ===================
 with a class {.myclass}
 ------------
-multiple! {.myclass1 #myh3 .myclass2}
+with a custom attribute {myattr=myvalue}
+========================================
+multiple! {.myclass1 myattr #myh3 otherattr=value .myclass2}
 --
 .
 <h1 id="myh1">with the ID</h1>
 <h2 class="myclass">with a class</h2>
-<h2 id="myh3" class="myclass1 myclass2">multiple!</h2>
+<h1 myattr="myvalue">with a custom attribute</h1>
+<h2 id="myh3" class="myclass1 myclass2" myattr otherattr="value">multiple!</h2>
 ````````````````````````````````
 
 Basic usage with ATX headings:
@@ -37,11 +41,13 @@ Basic usage with ATX headings:
 ```````````````````````````````` example
 # with the ID {#myh1}
 ## with a class {.myclass}
-### multiple! {.myclass1 #myh3 .myclass2}
+#### with a custom attribute {myattr=myvalue}
+### multiple! {.myclass1 myattr #myh3 otherattr=value .myclass2}
 .
 <h1 id="myh1">with the ID</h1>
 <h2 class="myclass">with a class</h2>
-<h3 id="myh3" class="myclass1 myclass2">multiple!</h3>
+<h4 myattr="myvalue">with a custom attribute</h4>
+<h3 id="myh3" class="myclass1 myclass2" myattr otherattr="value">multiple!</h3>
 ````````````````````````````````
 
 If an ATX heading has closing `#`s, the attribute block should be placed after them.
@@ -284,19 +290,20 @@ When both an ID and classes are specified, ID attribute is always emitted first.
 <h2 id="m" class="z a">H2</h2>
 ````````````````````````````````
 
-# Unknown attributes
+# Custom attributes
 
-Unknown attributes are simply ignored.
-Note that it cause neither an error nor a fallback to non-extended markdown,
-since this other attributes can be supported by other implementations or this
-crate in future.
+Custom attributes can optionally have a value. If they don't have a `=` symbol,
+their value is `None` and they are written in HTML with an empty value. When 
+nothing follows a `=` symbol, their value is an empty string and they are
+written in HTML with an empty value too. When something follows a `=` symbol,
+that characters are their value.
 
 ```````````````````````````````` example
 # H1 {foo}
 ## H2 {#myid unknown this#is.ignored attr=value .myclass}
 .
-<h1>H1</h1>
-<h2 id="myid" class="myclass">H2</h2>
+<h1 foo="">H1</h1>
+<h2 id="myid" unknown="" this#is.ignored="" attr="value" class="myclass">H2</h2>
 ````````````````````````````````
 
 # Forbidden characters
@@ -540,7 +547,7 @@ to wrap attributes and it is safe to put single quotes inside them.
 Markdown processor cannot abort on syntax error, so some output is required for
 any input, even if it is obviously wrong or looks very weird.
 However, attribute blocks is extended syntax with neither de jure nor de facto
-stardard, so uncommon cases will lead to possibly unexpected output that is
+standard, so uncommon cases will lead to possibly unexpected output that is
 incompatible with other implementations.
 
 Users should not rely on the current behavior on these weird edge case inputs.

--- a/specs/heading_attrs.txt
+++ b/specs/heading_attrs.txt
@@ -306,6 +306,18 @@ that characters are their value.
 <h2 id="myid" unknown="" this#is.ignored="" attr="value" class="myclass">H2</h2>
 ````````````````````````````````
 
+```````````````````````````````` example
+# Header # {myattr=value other_attr}
+.
+<h1 myattr="value" other_attr="">Header</h1>
+````````````````````````````````
+
+```````````````````````````````` example
+#### Header {#id myattr= .class1 other_attr=false}
+.
+<h4 id="id" myattr="" class="class1" other_attr="false">Header</h4>
+````````````````````````````````
+
 # Forbidden characters
 
 Some characters cannot appear in attribute blocks.
@@ -324,7 +336,7 @@ Left curly brace (note that `{unknown}` and `{.bar}` are treated as attribute bl
 # H1 {.foo{unknown}
 ## H2 {.foo{.bar}
 .
-<h1>H1 {.foo</h1>
+<h1 unknown="">H1 {.foo</h1>
 <h2 class="bar">H2 {.foo</h2>
 ````````````````````````````````
 

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -1655,6 +1655,7 @@ fn extract_attribute_block_content_from_header_text(
 fn parse_inside_attribute_block(inside_attr_block: &str) -> Option<HeadingAttributes> {
     let mut id = None;
     let mut classes = Vec::new();
+    let mut attrs = Vec::new();
 
     for attr in inside_attr_block.split_ascii_whitespace() {
         // iterator returned by `str::split_ascii_whitespace` never emits empty
@@ -1665,11 +1666,18 @@ fn parse_inside_attribute_block(inside_attr_block: &str) -> Option<HeadingAttrib
                 id = Some(&attr[1..]);
             } else if first_byte == b'.' {
                 classes.push(&attr[1..]);
+            } else {
+                let split = attr.split_once('=');
+                if let Some((key, value)) = split {
+                    attrs.push((key, Some(value)));
+                } else {
+                    attrs.push((attr, None));
+                }
             }
         }
     }
 
-    Some(HeadingAttributes { id, classes })
+    Some(HeadingAttributes { id, classes, attrs })
 }
 
 #[cfg(all(target_arch = "x86_64", feature = "simd"))]

--- a/src/html.rs
+++ b/src/html.rs
@@ -147,7 +147,12 @@ where
                     self.write("\n<p>")
                 }
             }
-            Tag::Heading(level, id, classes) => {
+            Tag::Heading {
+                level,
+                id,
+                classes,
+                attrs,
+            } => {
                 if self.end_newline {
                     self.end_newline = false;
                     self.write("<")?;
@@ -169,6 +174,17 @@ where
                         escape_html(&mut self.writer, class)?;
                     }
                     self.write("\"")?;
+                }
+                for (attr, value) in attrs {
+                    self.write(" ")?;
+                    escape_html(&mut self.writer, attr)?;
+                    if let Some(val) = value {
+                        self.write("=\"")?;
+                        escape_html(&mut self.writer, val)?;
+                        self.write("\"")?;
+                    } else {
+                        self.write("=\"\"")?;
+                    }
                 }
                 self.write(">")
             }
@@ -309,7 +325,12 @@ where
             Tag::Paragraph => {
                 self.write("</p>\n")?;
             }
-            Tag::Heading(level, _id, _classes) => {
+            Tag::Heading {
+                level,
+                id: _,
+                classes: _,
+                attrs: _,
+            } => {
                 self.write("</")?;
                 write!(&mut self.writer, "{}", level)?;
                 self.write(">\n")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,17 @@ pub enum Tag<'a> {
     /// A paragraph of text and other inline elements.
     Paragraph,
 
-    /// A heading. The first field indicates the level of the heading,
-    /// the second the fragment identifier, and the third the classes.
-    Heading(HeadingLevel, Option<&'a str>, Vec<&'a str>),
+    /// A heading, with optional identifier, classes and custom attributes.
+    /// The identifier is prefixed with `#` and the last one in the attributes
+    /// list is chosen, classes are prefixed with `.` and custom attributes
+    /// have no prefix and can optionally have a value (`myattr` o `myattr=myvalue`).
+    Heading {
+        level: HeadingLevel,
+        id: Option<&'a str>,
+        classes: Vec<&'a str>,
+        /// The first item of the tuple is the attr and second one the value.
+        attrs: Vec<(&'a str, Option<&'a str>)>,
+    },
 
     BlockQuote,
     /// A code block.
@@ -282,8 +290,11 @@ bitflags::bitflags! {
         const ENABLE_SMART_PUNCTUATION = 1 << 5;
         /// Extension to allow headings to have ID and classes.
         ///
-        /// `# text { #id .class1 .class2 }` is interpreted as a level 1 heading
-        /// with the content `text`, ID `id`, and classes `class1` and `class2`.
+        /// `# text { #id .class1 .class2 myattr, other_attr=myvalue }`
+        /// is interpreted as a level 1 heading
+        /// with the content `text`, ID `id`, classes `class1` and `class2` and
+        /// custom attributes `myattr` (without value) and
+        /// `other_attr` with value `myvalue`.
         /// Note that attributes (ID and classes) should be space-separated.
         const ENABLE_HEADING_ATTRIBUTES = 1 << 6;
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -146,7 +146,7 @@ pub struct Parser<'input, 'callback> {
 
 impl<'input, 'callback> std::fmt::Debug for Parser<'input, 'callback> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Only print the fileds that have public types.
+        // Only print the fields that have public types.
         f.debug_struct("Parser")
             .field("text", &self.text)
             .field("options", &self.options)
@@ -1243,6 +1243,7 @@ pub(crate) struct Allocations<'a> {
 pub(crate) struct HeadingAttributes<'a> {
     pub id: Option<&'a str>,
     pub classes: Vec<&'a str>,
+    pub attrs: Vec<(&'a str, Option<&'a str>)>,
 }
 
 /// Keeps track of the reference definitions defined in the document.
@@ -1417,10 +1418,20 @@ fn item_to_tag<'a>(item: &Item, allocs: &Allocations<'a>) -> Tag<'a> {
             Tag::Image(*link_type, url.clone(), title.clone())
         }
         ItemBody::Heading(level, Some(heading_ix)) => {
-            let HeadingAttributes { id, classes } = allocs.index(heading_ix);
-            Tag::Heading(level, *id, classes.clone())
+            let HeadingAttributes { id, classes, attrs } = allocs.index(heading_ix);
+            Tag::Heading {
+                level,
+                id: *id,
+                classes: classes.clone(),
+                attrs: attrs.clone(),
+            }
         }
-        ItemBody::Heading(level, None) => Tag::Heading(level, None, Vec::new()),
+        ItemBody::Heading(level, None) => Tag::Heading {
+            level,
+            id: None,
+            classes: Vec::new(),
+            attrs: Vec::new(),
+        },
         ItemBody::FencedCodeBlock(cow_ix) => {
             Tag::CodeBlock(CodeBlockKind::Fenced(allocs[cow_ix].clone()))
         }
@@ -1472,10 +1483,20 @@ fn item_to_event<'a>(item: Item, text: &'a str, allocs: &Allocations<'a>) -> Eve
             Tag::Image(*link_type, url.clone(), title.clone())
         }
         ItemBody::Heading(level, Some(heading_ix)) => {
-            let HeadingAttributes { id, classes } = allocs.index(heading_ix);
-            Tag::Heading(level, *id, classes.clone())
+            let HeadingAttributes { id, classes, attrs } = allocs.index(heading_ix);
+            Tag::Heading {
+                level,
+                id: *id,
+                classes: classes.clone(),
+                attrs: attrs.clone(),
+            }
         }
-        ItemBody::Heading(level, None) => Tag::Heading(level, None, Vec::new()),
+        ItemBody::Heading(level, None) => Tag::Heading {
+            level,
+            id: None,
+            classes: Vec::new(),
+            attrs: Vec::new(),
+        },
         ItemBody::FencedCodeBlock(cow_ix) => {
             Tag::CodeBlock(CodeBlockKind::Fenced(allocs[cow_ix].clone()))
         }

--- a/tests/suite/heading_attrs.rs
+++ b/tests/suite/heading_attrs.rs
@@ -270,8 +270,8 @@ fn heading_attrs_test_20() {
     let original = r##"# H1 {foo}
 ## H2 {#myid unknown this#is.ignored attr=value .myclass}
 "##;
-    let expected = r##"<h1>H1</h1>
-<h2 id="myid" class="myclass">H2</h2>
+    let expected = r##"<h1 foo>H1</h1>
+<h2 id="myid" unknown="" this#is.ignored="" attr="value" class="myclass">H2</h2>
 "##;
 
     test_markdown_html(original, expected, false);
@@ -282,7 +282,7 @@ fn heading_attrs_test_21() {
     let original = r##"# H1 {.foo{unknown}
 ## H2 {.foo{.bar}
 "##;
-    let expected = r##"<h1>H1 {.foo</h1>
+    let expected = r##"<h1 unknown="">H1 {.foo</h1>
 <h2 class="bar">H2 {.foo</h2>
 "##;
 
@@ -566,6 +566,22 @@ fn heading_attrs_test_40() {
     let expected = r##"<h1 id="en-space .myclass">EN SPACE (U+2002)</h1>
 <h2 id="ideographic-space　.myclass">IDEOGRAPHIC SPACE (U+3000)</h2>
 "##;
+
+    test_markdown_html(original, expected, false);
+}
+
+#[test]
+fn heading_attrs_test_41() {
+    let original = r##"# Header # {myattr=value other_attr}"##;
+    let expected = r##"<h1 myattr="value" other_attr="">Header</h1>"##;
+
+    test_markdown_html(original, expected, false);
+}
+
+#[test]
+fn heading_attrs_test_42() {
+    let original = r##"#### Header {#id myattr= .class1 other_attr=false}"##;
+    let expected = r##"<h4 id="id" myattr="" class="class1" other_attr="false">Header</h4>"##;
 
     test_markdown_html(original, expected, false);
 }

--- a/tests/suite/heading_attrs.rs
+++ b/tests/suite/heading_attrs.rs
@@ -9,12 +9,15 @@ fn heading_attrs_test_1() {
 ===================
 with a class {.myclass}
 ------------
-multiple! {.myclass1 #myh3 .myclass2}
+with a custom attribute {myattr=myvalue}
+========================================
+multiple! {.myclass1 myattr #myh3 otherattr=value .myclass2}
 --
 "##;
     let expected = r##"<h1 id="myh1">with the ID</h1>
 <h2 class="myclass">with a class</h2>
-<h2 id="myh3" class="myclass1 myclass2">multiple!</h2>
+<h1 myattr="myvalue">with a custom attribute</h1>
+<h2 id="myh3" class="myclass1 myclass2" myattr otherattr="value">multiple!</h2>
 "##;
 
     test_markdown_html(original, expected, false);
@@ -24,11 +27,13 @@ multiple! {.myclass1 #myh3 .myclass2}
 fn heading_attrs_test_2() {
     let original = r##"# with the ID {#myh1}
 ## with a class {.myclass}
-### multiple! {.myclass1 #myh3 .myclass2}
+#### with a custom attribute {myattr=myvalue}
+### multiple! {.myclass1 myattr #myh3 otherattr=value .myclass2}
 "##;
     let expected = r##"<h1 id="myh1">with the ID</h1>
 <h2 class="myclass">with a class</h2>
-<h3 id="myh3" class="myclass1 myclass2">multiple!</h3>
+<h4 myattr="myvalue">with a custom attribute</h4>
+<h3 id="myh3" class="myclass1 myclass2" myattr otherattr="value">multiple!</h3>
 "##;
 
     test_markdown_html(original, expected, false);
@@ -270,7 +275,7 @@ fn heading_attrs_test_20() {
     let original = r##"# H1 {foo}
 ## H2 {#myid unknown this#is.ignored attr=value .myclass}
 "##;
-    let expected = r##"<h1 foo>H1</h1>
+    let expected = r##"<h1 foo="">H1</h1>
 <h2 id="myid" unknown="" this#is.ignored="" attr="value" class="myclass">H2</h2>
 "##;
 
@@ -279,6 +284,26 @@ fn heading_attrs_test_20() {
 
 #[test]
 fn heading_attrs_test_21() {
+    let original = r##"# Header # {myattr=value other_attr}
+"##;
+    let expected = r##"<h1 myattr="value" other_attr="">Header</h1>
+"##;
+
+    test_markdown_html(original, expected, false);
+}
+
+#[test]
+fn heading_attrs_test_22() {
+    let original = r##"#### Header {#id myattr= .class1 other_attr=false}
+"##;
+    let expected = r##"<h4 id="id" myattr="" class="class1" other_attr="false">Header</h4>
+"##;
+
+    test_markdown_html(original, expected, false);
+}
+
+#[test]
+fn heading_attrs_test_23() {
     let original = r##"# H1 {.foo{unknown}
 ## H2 {.foo{.bar}
 "##;
@@ -290,7 +315,7 @@ fn heading_attrs_test_21() {
 }
 
 #[test]
-fn heading_attrs_test_22() {
+fn heading_attrs_test_24() {
     let original = r##"# H1 {.foo}bar}
 "##;
     let expected = r##"<h1>H1 {.foo}bar}</h1>
@@ -300,7 +325,7 @@ fn heading_attrs_test_22() {
 }
 
 #[test]
-fn heading_attrs_test_23() {
+fn heading_attrs_test_25() {
     let original = r##"# H1 {<i>foo</i>}
 "##;
     let expected = r##"<h1>H1 {<i>foo</i>}</h1>
@@ -310,7 +335,7 @@ fn heading_attrs_test_23() {
 }
 
 #[test]
-fn heading_attrs_test_24() {
+fn heading_attrs_test_26() {
     let original = r##"# H1 {.foo\}
 "##;
     let expected = r##"<h1>H1 {.foo}</h1>
@@ -320,7 +345,7 @@ fn heading_attrs_test_24() {
 }
 
 #[test]
-fn heading_attrs_test_25() {
+fn heading_attrs_test_27() {
     let original = r##"H1 {.foo
 .bar}
 ==
@@ -333,7 +358,7 @@ fn heading_attrs_test_25() {
 }
 
 #[test]
-fn heading_attrs_test_26() {
+fn heading_attrs_test_28() {
     let original = r##"H1 {} {}
 =====
 
@@ -347,7 +372,7 @@ fn heading_attrs_test_26() {
 }
 
 #[test]
-fn heading_attrs_test_27() {
+fn heading_attrs_test_29() {
     let original = r##"## H2 {} ##
 "##;
     let expected = r##"<h2>H2 {}</h2>
@@ -357,7 +382,7 @@ fn heading_attrs_test_27() {
 }
 
 #[test]
-fn heading_attrs_test_28() {
+fn heading_attrs_test_30() {
     let original = r##"# H1 {\}
 ## this is also ok \{\}
 
@@ -375,7 +400,7 @@ newline can be used for setext heading {
 }
 
 #[test]
-fn heading_attrs_test_29() {
+fn heading_attrs_test_31() {
     let original = r##"# H1 \{.foo}
 ## H2 \\{.bar}
 ### stray backslash at the end is preserved \
@@ -389,7 +414,7 @@ fn heading_attrs_test_29() {
 }
 
 #[test]
-fn heading_attrs_test_30() {
+fn heading_attrs_test_32() {
     let original = r##"H1 \{.foo}
 ==
 H2 \\{.bar}
@@ -407,7 +432,7 @@ stray backslash at the end is preserved \
 }
 
 #[test]
-fn heading_attrs_test_31() {
+fn heading_attrs_test_33() {
     let original = r##"# H1 {#`code`}
 ## H2 {#foo__bar__baz}
 ### H3 {#foo**bar**baz}
@@ -421,7 +446,7 @@ fn heading_attrs_test_31() {
 }
 
 #[test]
-fn heading_attrs_test_32() {
+fn heading_attrs_test_34() {
     let original = r##"H1 {#`code`}
 ==
 
@@ -440,7 +465,7 @@ H2-2 {#foo**bar**baz}
 }
 
 #[test]
-fn heading_attrs_test_33() {
+fn heading_attrs_test_35() {
     let original = r##"# H1 {.foo#bar}
 ## H2 {#foo.bar}
 ### H3 {.a"b'c&d}
@@ -454,7 +479,7 @@ fn heading_attrs_test_33() {
 }
 
 #[test]
-fn heading_attrs_test_34() {
+fn heading_attrs_test_36() {
     let original = r##"# H1 {#}
 ## H2 {.}
 "##;
@@ -466,7 +491,7 @@ fn heading_attrs_test_34() {
 }
 
 #[test]
-fn heading_attrs_test_35() {
+fn heading_attrs_test_37() {
     let original = r##"# H1 {#foo #}
 # H1 {.foo . . .bar}
 "##;
@@ -478,7 +503,7 @@ fn heading_attrs_test_35() {
 }
 
 #[test]
-fn heading_attrs_test_36() {
+fn heading_attrs_test_38() {
     let original = r##"# {}
 ## {}
 ### {\}
@@ -497,7 +522,7 @@ fn heading_attrs_test_36() {
 }
 
 #[test]
-fn heading_attrs_test_37() {
+fn heading_attrs_test_39() {
     let original = r##"{}
 ==
 
@@ -524,7 +549,7 @@ fn heading_attrs_test_37() {
 }
 
 #[test]
-fn heading_attrs_test_38() {
+fn heading_attrs_test_40() {
     let original = r##"# horizontal tab	
 # horizontal tab	{#ht}
 ## form feed
@@ -544,7 +569,7 @@ fn heading_attrs_test_38() {
 }
 
 #[test]
-fn heading_attrs_test_39() {
+fn heading_attrs_test_41() {
     let original = r##"# horizontal tab (U+000A) {#ht	.myclass}
 ## form feed (U+000C) {#ff.myclass}
 
@@ -559,29 +584,13 @@ fn heading_attrs_test_39() {
 }
 
 #[test]
-fn heading_attrs_test_40() {
+fn heading_attrs_test_42() {
     let original = r##"# EN SPACE (U+2002) {#en-space .myclass}
 ## IDEOGRAPHIC SPACE (U+3000) {#ideographic-space　.myclass}
 "##;
     let expected = r##"<h1 id="en-space .myclass">EN SPACE (U+2002)</h1>
 <h2 id="ideographic-space　.myclass">IDEOGRAPHIC SPACE (U+3000)</h2>
 "##;
-
-    test_markdown_html(original, expected, false);
-}
-
-#[test]
-fn heading_attrs_test_41() {
-    let original = r##"# Header # {myattr=value other_attr}"##;
-    let expected = r##"<h1 myattr="value" other_attr="">Header</h1>"##;
-
-    test_markdown_html(original, expected, false);
-}
-
-#[test]
-fn heading_attrs_test_42() {
-    let original = r##"#### Header {#id myattr= .class1 other_attr=false}"##;
-    let expected = r##"<h4 id="id" myattr="" class="class1" other_attr="false">Header</h4>"##;
 
     test_markdown_html(original, expected, false);
 }


### PR DESCRIPTION
This feature is a breaking change because it modifies the `Heading` variant of the `Tag` enum with named fields and the new `attrs` field.

Fixes: #634