### PR TITLE
Experiment with tweaking Rust install

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ pool:
 steps:
   - script: |
       rustup default 1.56.0
-      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     displayName: Set default Rust toolchain
   - script: cargo build --all
     displayName: Cargo build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,9 @@ pool:
 
 steps:
   - script: |
-      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.56.0
+      rustup default 1.56.0
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-    displayName: Install rust
+    displayName: Set default Rust toolchain
   - script: cargo build --all
     displayName: Cargo build
   - script: cargo test --all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,20 +1,13 @@
 pool:
   vmImage: 'ubuntu-20.04'
 
-steps:
-  - script: |
-      rustup default 1.56.0
-    displayName: Set default Rust toolchain
-  - script: cargo build --all
-    displayName: Cargo build
-  - script: cargo test --all
-    displayName: Cargo test
-  - script: cargo test --all --features=simd,gen-tests
-    displayName: Cargo test with simd feature enabled
-  - script: cargo test --all --features=serde
-    displayName: Cargo test with serde feature enabled
-  - script: cargo test --all --no-default-features
-    displayName: Cargo test without default features    
-  - script: cargo run --release -- --regressions
-    workingDirectory: fuzzer
-    displayName: Test for superlinear time regressions
+jobs:
+ - template: default.yml@templates
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: crate-ci/azure-pipelines
+      ref: refs/heads/v0.4
+      endpoint: marcusklaas

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,3 @@
-pool:
-  vmImage: 'ubuntu-20.04'
-
 jobs:
  - template: default.yml@templates
 


### PR DESCRIPTION
Currently it's downloading Rust from rustup.rs, but I think that's not necessary as there's already a Rust installed. This patch changes it to assume there's already a rustup to set the default toolchain.