### PR TITLE
Add an example which shows raw Markdown events

### DIFF
--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,22 @@
+use std::io::Read;
+
+use pulldown_cmark::{Event, Parser};
+
+/// Show all events from the text on stdin.
+fn main() {
+    let mut text = String::new();
+    std::io::stdin().read_to_string(&mut text).unwrap();
+
+    eprintln!("{text:?} -> [");
+    let mut width = 0;
+    for event in Parser::new(&text) {
+        if let Event::End(_) = event {
+            width -= 2;
+        }
+        eprintln!("  {:width$}{event:?}", "");
+        if let Event::Start(_) = event {
+            width += 2;
+        }
+    }
+    eprintln!("]");
+}


### PR DESCRIPTION
I’ve found this to be a very useful tool when looking at parse output. This is similar to parser-map-event-print.rs, but it shows the events using their debug representation and it avoids printing HTML.