### PR TITLE
Fix index out of bounds when parsing GFM footnote

### DIFF
--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -1420,9 +1420,10 @@ fn scan_paragraph_interrupt(bytes: &[u8], current_container: bool, gfm_footnote:
         })
         || bytes.starts_with(b"<")
             && (get_html_end_tag(&bytes[1..]).is_some() || starts_html_block_type_6(&bytes[1..]))
-        || (gfm_footnote && bytes.starts_with(b"[^") && scan_link_label_rest(std::str::from_utf8(&bytes[2..]).unwrap(), &|_| None).map_or(false, |(len, _)| {
-            bytes[2 + len] == b':'
-        }))
+        || (gfm_footnote
+            && bytes.starts_with(b"[^")
+            && scan_link_label_rest(std::str::from_utf8(&bytes[2..]).unwrap(), &|_| None)
+                .map_or(false, |(len, _)| bytes.get(2 + len) == Some(&b':')))
 }
 
 /// Assumes `text_bytes` is preceded by `<`.

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -86,6 +86,15 @@ fn test_fuzzer_input_12() {
 }
 
 #[test]
+fn test_fuzzer_input_13() {
+    // Does not fail with Options::all():
+    Parser::new_ext(
+        ".\r> ^](\r\u{c}\r\0\0\r.\r[^\0\0\\\0\0\0^^^^^]",
+        Options::ENABLE_FOOTNOTES,
+    );
+}
+
+#[test]
 fn test_wrong_code_block() {
     parse(
         r##"```


### PR DESCRIPTION
The code here was introduced in #654 and the crash was found using

    cargo fuzz run parse

Fixes #666.