### PR TITLE
feat: `TextMergeStream` utility to merge consecutive text events

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ for event in parser {
 }
 ```
 
+Note that consecutive text events can happen due to the manner in which the
+parser evaluates the source. A utility `TextMergeStream` exists to improve
+the comfort of iterating the events:
+
+```rust
+use pulldown_cmark::{Event, Parser, Options};
+
+let markdown_input = "Hello world, this is a ~~complicated~~ *very simple* example.";
+
+let iterator = TextMergeStream::new(Parser::new(markdown_input));
+
+for event in iterator {
+    match event {
+        Event::Text(text) => println!("{}", text),
+        _ => {}
+    }
+}
+```
+
 There are some basic but fully functional examples of the usage of the crate in the
 `examples` directory of this repository.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,26 @@
 //! assert_eq!(expected_html, &html_output);
 //! # }
 //! ```
+//!
+//! Note that consecutive text events can happen due to the manner in which the
+//! parser evaluates the source. A utility `TextMergeStream` exists to improve
+//! the comfort of iterating the events:
+//!
+//! ```rust
+//! use pulldown_cmark::{Event, Parser, TextMergeStream};
+//!
+//! let markdown_input = "Hello world, this is a ~~complicated~~ *very simple* example.";
+//!
+//! let iterator = TextMergeStream::new(Parser::new(markdown_input));
+//!
+//! for event in iterator {
+//!     match event {
+//!         Event::Text(text) => println!("{}", text),
+//!         _ => {}
+//!     }
+//! }
+//! ```
+//!
 
 // When compiled for the rustc compiler itself we want to make sure that this is
 // an unstable crate.
@@ -65,6 +85,8 @@ pub mod escape;
 #[cfg(feature = "html")]
 pub mod html;
 
+pub mod utils;
+
 mod entities;
 mod firstpass;
 mod linklabel;
@@ -78,6 +100,7 @@ use std::{convert::TryFrom, fmt::Display};
 
 pub use crate::parse::{BrokenLink, BrokenLinkCallback, LinkDef, OffsetIter, Parser, RefDefs};
 pub use crate::strings::{CowStr, InlineStr};
+pub use crate::utils::*;
 
 /// Codeblock kind.
 #[derive(Clone, Debug, PartialEq)]
@@ -341,17 +364,17 @@ bitflags::bitflags! {
         ///
         /// Footnotes are referenced with the syntax `[^IDENT]`,
         /// and defined with an identifier followed by a colon at top level.
-        /// 
+        ///
         /// ---
         ///
         /// ```markdown
         /// Footnote referenced [^1].
-        /// 
+        ///
         /// [^1]: footnote defined
         /// ```
-        /// 
+        ///
         /// Footnote referenced [^1].
-        /// 
+        ///
         /// [^1]: footnote defined
         const ENABLE_FOOTNOTES = 1 << 2;
         const ENABLE_STRIKETHROUGH = 1 << 3;
@@ -379,17 +402,17 @@ bitflags::bitflags! {
         ///
         /// New syntax is different from the old syntax regarding
         /// indentation, nesting, and footnote references with no definition:
-        /// 
+        ///
         /// ```markdown
         /// [^1]: In new syntax, this is two footnote definitions.
         /// [^2]: In old syntax, this is a single footnote definition with two lines.
-        /// 
+        ///
         /// [^3]:
-        /// 
+        ///
         ///     In new syntax, this is a footnote with two paragraphs.
-        /// 
+        ///
         ///     In old syntax, this is a footnote followed by a code block.
-        /// 
+        ///
         /// In new syntax, this undefined footnote definition renders as
         /// literal text [^4]. In old syntax, it creates a dangling link.
         /// ```

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,76 @@
+//! Miscellaneous utilities to incraese comfort.
+//! Special thanks to
+//! https://github.com/BenjaminRi/Redwood-Wiki/blob/master/src/markdown_utils.rs.
+//! Its author authorized the use of this GPL code in this project in
+//! https://github.com/raphlinus/pulldown-cmark/issues/507.
+
+use crate::{CowStr, Event};
+
+/// Merge consecutive `Event::Text` events into only one.
+#[derive(Debug)]
+pub struct TextMergeStream<'a, I> {
+    iter: I,
+    last_event: Option<Event<'a>>,
+}
+
+impl<'a, I> TextMergeStream<'a, I>
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    pub fn new(iter: I) -> Self {
+        Self {
+            iter,
+            last_event: None,
+        }
+    }
+}
+
+impl<'a, I> Iterator for TextMergeStream<'a, I>
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    type Item = Event<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.last_event.take(), self.iter.next()) {
+            (Some(Event::Text(last_text)), Some(Event::Text(next_text))) => {
+                // We need to start merging consecutive text events together into one
+                let mut string_buf: String = last_text.into_string();
+                string_buf.push_str(&next_text);
+                loop {
+                    // Avoid recursion to avoid stack overflow and to optimize concatenation
+                    match self.iter.next() {
+                        Some(Event::Text(next_text)) => {
+                            string_buf.push_str(&next_text);
+                        }
+                        next_event => {
+                            self.last_event = next_event;
+                            if string_buf.is_empty() {
+                                // Discard text event(s) altogether if there is no text
+                                break self.next();
+                            } else {
+                                break Some(Event::Text(CowStr::Boxed(
+                                    string_buf.into_boxed_str(),
+                                )));
+                            }
+                        }
+                    }
+                }
+            }
+            (None, Some(next_event)) => {
+                // This only happens once during the first iteration and if there are items
+                self.last_event = Some(next_event);
+                self.next()
+            }
+            (None, None) => {
+                // This happens when the iterator is depleted
+                None
+            }
+            (last_event, next_event) => {
+                // The ordinary case, emit one event after the other without modification
+                self.last_event = next_event;
+                last_event
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix the consecutive text events issue commented in #507.