### PR TITLE
Add special handling for backslash-escaped pipes in codeblocks

### DIFF
--- a/specs/table.txt
+++ b/specs/table.txt
@@ -449,3 +449,66 @@ a\
 <tr><td>d</td><td>e</td></tr>
 </tbody></table>
 ````````````````````````````````
+
+
+As a special case, pipes in code blocks in tables are escaped
+with backslashes.
+
+The rule is that, if a backslash run (a series of at least one uninterrupted
+backslashes) comes immediately before a pipe:
+
+* If the number of backslashes is even, then it doesn't escape the pipe.
+* If the number of backslashes is odd, then it escapes the pipe, and it
+  renders `floor(n / 2)` backslashes.
+
+This rule is similar to GitHub's, but not identical. See
+<https://gist.github.com/notriddle/c027512ee849f12098fec3a3256c89d3>
+for what they do. The "Wait, what?" examples are where we diverge,
+and the final three examples are why. In any case, all of GitHub's
+documented examples pass: it just differs in really weird corner cases.
+
+It's a lot closer to the behavior of Pandoc's `commonmark_x`, but they don't
+do the divide-by-two behavior. This means Pandoc's version turns `\|` into a
+literal pipe (just like GitHub and pulldown-cmark do), turns `\\|` into a
+literal backslash plus a table cell marker (which is what pulldown-cmark does,
+but not what GitHub does), and turns `\\\|` into two literal backslashes
+plus a literal pipe (which means there's no way to represent a single
+backslash followed by a single pipe in their syntax).
+
+```````````````````````````````` example
+| Description | Test case |
+|-------------|-----------|
+| Single      | `\`       |
+| Double      | `\\`      |
+| Basic test  | `\|`      |
+| Basic test 2| `\|\|\`   |
+| Basic test 3| `x\|y\|z\`|
+| Not pipe    | `\.`      |
+| Combo       | `\.\|\`   |
+| Extra       | `\\\.`    |
+| Wait, what? | `\\|`     |
+| Wait, what? | `\\\|`    |
+| Wait, what? | `\\\\|`   |
+| Wait, what? | `\\\\\|`  |
+| Wait, what? |          \|
+| Wait, what? |         \\|
+| Wait, what? |        \\\|
+.
+<table><thead><tr><th>Description</th><th>Test case</th></tr></thead><tbody>
+<tr><td>Single</td><td><code>\</code></td></tr>
+<tr><td>Double</td><td><code>\\</code></td></tr>
+<tr><td>Basic test</td><td><code>|</code></td></tr>
+<tr><td>Basic test 2</td><td><code>||\</code></td></tr>
+<tr><td>Basic test 3</td><td><code>x|y|z\</code></td></tr>
+<tr><td>Not pipe</td><td><code>\.</code></td></tr>
+<tr><td>Combo</td><td><code>\.|\</code></td></tr>
+<tr><td>Extra</td><td><code>\\\.</code></td></tr>
+<tr><td>Wait, what?</td><td>`\</td></tr>
+<tr><td>Wait, what?</td><td><code>\|</code></td></tr>
+<tr><td>Wait, what?</td><td>`\\</td></tr>
+<tr><td>Wait, what?</td><td><code>\\|</code></td></tr>
+<tr><td>Wait, what?</td><td>|</td></tr>
+<tr><td>Wait, what?</td><td>\</td></tr>
+<tr><td>Wait, what?</td><td>\|</td></tr>
+</tbody></table>
+````````````````````````````````

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -812,6 +812,11 @@ impl<'input, 'callback> Parser<'input, 'callback> {
 
             while ix != close {
                 let next_ix = self.tree[ix].next.unwrap();
+                let end = if next_ix == close {
+                    span_end
+                } else {
+                    self.tree[next_ix].item.start
+                };
                 if let ItemBody::HardBreak | ItemBody::SoftBreak = self.tree[ix].item.body {
                     if drop_enclosing_whitespace {
                         // check whether break should be ignored
@@ -838,12 +843,37 @@ impl<'input, 'callback> Parser<'input, 'callback> {
                         new_buf.push(' ');
                         buf = Some(new_buf);
                     }
+                } else if self.tree.is_in_table() && self.text[self.tree[ix].item.start..end].contains("|") {
+                    for (i, c) in bytes[self.tree[ix].item.start..end].into_iter().copied().enumerate() {
+                        if c != b'|' {
+                            continue;
+                        }
+                        let pipe_position = self.tree[ix].item.start + i;
+                        let buf = if let Some(ref mut buf) = buf {
+                            buf.push_str(&self.text[self.tree[ix].item.start..pipe_position]);
+                            buf
+                        } else {
+                            let mut new_buf = String::with_capacity(pipe_position - span_start);
+                            new_buf.push_str(&self.text[span_start..pipe_position]);
+                            buf.insert(new_buf)
+                        };
+                        let mut backslash_count = 0;
+                        for c in buf.bytes().rev() {
+                            if c == b'\\' {
+                                backslash_count += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        assert!(
+                            backslash_count % 2 == 1,
+                            "if number of backslashes were even, pipe wouldn't be escaped",
+                        );
+                        let trim = (backslash_count / 2) + 1;
+                        buf.truncate(buf.len() - trim);
+                        buf.push_str(&self.text[pipe_position..end]);
+                    }
                 } else if let Some(ref mut buf) = buf {
-                    let end = if next_ix == close {
-                        span_end
-                    } else {
-                        self.tree[ix].item.end
-                    };
                     buf.push_str(&self.text[self.tree[ix].item.start..end]);
                 }
                 ix = next_ix;
@@ -952,6 +982,31 @@ impl<'a> Tree<Item> {
                 body: ItemBody::Text,
             });
         }
+    }
+    /// Returns true if the current node is inside a table.
+    ///
+    /// If `cur` is an ItemBody::Table, it would return false,
+    /// but since the `TableRow` and `TableHead` and `TableCell`
+    /// are children of the table, anything doing inline parsing
+    /// doesn't need to care about that.
+    pub(crate) fn is_in_table(&self) -> bool {
+        fn might_be_in_table(item: &Item) -> bool {
+            item.body.is_inline() || matches!(
+                item.body,
+                | ItemBody::TableHead
+                | ItemBody::TableRow
+                | ItemBody::TableCell
+            )
+        }
+        for &ix in self.walk_spine().rev() {
+            if matches!(self[ix].item.body, ItemBody::Table(_)) {
+                return true;
+            }
+            if !might_be_in_table(&self[ix].item) {
+                return false;
+            }
+        }
+        false
     }
 }
 

--- a/tests/suite/gfm_table.rs
+++ b/tests/suite/gfm_table.rs
@@ -68,7 +68,7 @@ fn gfm_table_test_3() {
 </thead>
 <tbody>
 <tr>
-<td>b <code>\|</code> az</td>
+<td>b <code>|</code> az</td>
 </tr>
 <tr>
 <td>b <strong>|</strong> im</td>

--- a/tests/suite/table.rs
+++ b/tests/suite/table.rs
@@ -349,3 +349,45 @@ fn table_test_16() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn table_test_17() {
+    let original = r##"| Description | Test case |
+|-------------|-----------|
+| Single      | `\`       |
+| Double      | `\\`      |
+| Basic test  | `\|`      |
+| Basic test 2| `\|\|\`   |
+| Basic test 3| `x\|y\|z\`|
+| Not pipe    | `\.`      |
+| Combo       | `\.\|\`   |
+| Extra       | `\\\.`    |
+| Wait, what? | `\\|`     |
+| Wait, what? | `\\\|`    |
+| Wait, what? | `\\\\|`   |
+| Wait, what? | `\\\\\|`  |
+| Wait, what? |          \|
+| Wait, what? |         \\|
+| Wait, what? |        \\\|
+"##;
+    let expected = r##"<table><thead><tr><th>Description</th><th>Test case</th></tr></thead><tbody>
+<tr><td>Single</td><td><code>\</code></td></tr>
+<tr><td>Double</td><td><code>\\</code></td></tr>
+<tr><td>Basic test</td><td><code>|</code></td></tr>
+<tr><td>Basic test 2</td><td><code>||\</code></td></tr>
+<tr><td>Basic test 3</td><td><code>x|y|z\</code></td></tr>
+<tr><td>Not pipe</td><td><code>\.</code></td></tr>
+<tr><td>Combo</td><td><code>\.|\</code></td></tr>
+<tr><td>Extra</td><td><code>\\\.</code></td></tr>
+<tr><td>Wait, what?</td><td>`\</td></tr>
+<tr><td>Wait, what?</td><td><code>\|</code></td></tr>
+<tr><td>Wait, what?</td><td>`\\</td></tr>
+<tr><td>Wait, what?</td><td><code>\\|</code></td></tr>
+<tr><td>Wait, what?</td><td>|</td></tr>
+<tr><td>Wait, what?</td><td>\</td></tr>
+<tr><td>Wait, what?</td><td>\|</td></tr>
+</tbody></table>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}

--- a/third_party/GitHub/gfm_table.txt
+++ b/third_party/GitHub/gfm_table.txt
@@ -83,7 +83,7 @@ inline spans:
 </thead>
 <tbody>
 <tr>
-<td>b <code>\|</code> az</td>
+<td>b <code>|</code> az</td>
 </tr>
 <tr>
 <td>b <strong>|</strong> im</td>


### PR DESCRIPTION
Fixes #356

Compare with the rendering in [GitHub] and [Pandoc].

[GitHub]: https://gist.github.com/notriddle/c027512ee849f12098fec3a3256c89d3
[Pandoc]: https://pandoc.org/try/?params=%7B%22text%22%3A%22%7C+Description+%7C+Test+case+%7C%5Cn%7C-------------%7C-----------%7C%5Cn%7C+Single++++++%7C+%60%5C%5C%60+++++++%7C%5Cn%7C+Double++++++%7C+%60%5C%5C%5C%5C%60++++++%7C%5Cn%7C+Basic+test++%7C+%60%5C%5C%7C%60++++++%7C%5Cn%7C+Basic+test+2%7C+%60%5C%5C%7C%5C%5C%7C%5C%5C%60+++%7C%5Cn%7C+Basic+test+3%7C+%60x%5C%5C%7Cy%5C%5C%7Cz%5C%5C%60%7C%5Cn%7C+Not+pipe++++%7C+%60%5C%5C.%60++++++%7C%5Cn%7C+Combo+++++++%7C+%60%5C%5C.%5C%5C%7C%5C%5C%60+++%7C%5Cn%7C+Extra+++++++%7C+%60%5C%5C%5C%5C%5C%5C.%60++++%7C%5Cn%7C+Wait%2C+what%3F+%7C+%60%5C%5C%5C%5C%7C%60+++++%7C%5Cn%7C+Wait%2C+what%3F+%7C+%60%5C%5C%5C%5C%5C%5C%7C%60++++%7C%5Cn%7C+Wait%2C+what%3F+%7C+%60%5C%5C%5C%5C%5C%5C%5C%5C%7C%60+++%7C%5Cn%7C+Wait%2C+what%3F+%7C+%60%5C%5C%5C%5C%5C%5C%5C%5C%5C%5C%7C%60++%7C%5Cn%7C+Wait%2C+what%3F+%7C++++++++++%5C%5C%7C%5Cn%7C+Wait%2C+what%3F+%7C+++++++++%5C%5C%5C%5C%7C%5Cn%7C+Wait%2C+what%3F+%7C++++++++%5C%5C%5C%5C%5C%5C%7C%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22commonmark_x%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D