### PR TITLE
Add special handling for backslashed table pipes

### DIFF
--- a/specs/table.txt
+++ b/specs/table.txt
@@ -449,3 +449,100 @@ a\
 <tr><td>d</td><td>e</td></tr>
 </tbody></table>
 ````````````````````````````````
+
+
+As a special case, pipes in inline code in tables are escaped
+with backslashes.
+
+The parsing rule for CommonMark is that block structures are parsed before
+inline structures are. Normally, this means backslashes aren't allowed to have
+any effect on block structures at all. Tables do consider backslashes, but
+not the same way inline syntax does: they have higher precedence than anything
+else, as-if they were parsed in a completely separate pass.
+
+This rule should be identical to GitHub's. See
+<https://gist.github.com/notriddle/c027512ee849f12098fec3a3256c89d3>
+for what they do. This is totally different from Pandoc's `commonmark_x`,
+for example, and from many other Markdown parsers, because of some weird
+corner cases it creates.
+
+```````````````````````````````` example
+| Description | Test case |
+|-------------|-----------|
+| Single      | `\`       |
+| Double      | `\\`      |
+| Basic test  | `\|`      |
+| Basic test 2| `\|\|\`   |
+| Basic test 3| `x\|y\|z\`|
+| Not pipe    | `\.`      |
+| Combo       | `\.\|\`   |
+| Extra       | `\\\.`    |
+| Wait, what? | `\\|`     |
+| Wait, what? | `\\\|`    |
+| Wait, what? | `\\\\|`   |
+| Wait, what? | `\\\\\|`  |
+| Wait, what? |          \|
+| Wait, what? |         \\|
+| Wait, what? |        \\\|
+| Wait, what?x|          \|x
+| Wait, what?x|         \\|x
+| Wait, what?x|        \\\|x
+.
+<table><thead><tr><th>Description</th><th>Test case</th></tr></thead><tbody>
+<tr><td>Single</td><td><code>\</code></td></tr>
+<tr><td>Double</td><td><code>\\</code></td></tr>
+<tr><td>Basic test</td><td><code>|</code></td></tr>
+<tr><td>Basic test 2</td><td><code>||\</code></td></tr>
+<tr><td>Basic test 3</td><td><code>x|y|z\</code></td></tr>
+<tr><td>Not pipe</td><td><code>\.</code></td></tr>
+<tr><td>Combo</td><td><code>\.|\</code></td></tr>
+<tr><td>Extra</td><td><code>\\\.</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\|</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\\|</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\\\|</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\\\\|</code></td></tr>
+<tr><td>Wait, what?</td><td>|</td></tr>
+<tr><td>Wait, what?</td><td>|</td></tr>
+<tr><td>Wait, what?</td><td>\|</td></tr>
+<tr><td>Wait, what?x</td><td>|x</td></tr>
+<tr><td>Wait, what?x</td><td>|x</td></tr>
+<tr><td>Wait, what?x</td><td>\|x</td></tr>
+</tbody></table>
+````````````````````````````````
+
+
+Example with code blocks in the table's header.
+
+```````````````````````````````` example
+| Single | `\|` |
+|--|--|
+| Single | `\|` |
+
+
+| Double | `\\|` |
+|--|--|
+| Double | `\\|` |
+
+
+| Double Twice | `\\|\\|` |
+|--|--|
+| Double Twice | `\\|\\|` |
+
+
+| Triple | `\\\|` |
+|--|--|
+| Triple | `\\\|` |
+.
+<table><thead><tr><th>Single</th><th><code>|</code></th></tr></thead><tbody>
+<tr><td>Single</td><td><code>|</code></td></tr>
+</tbody></table>
+<table><thead><tr><th>Double</th><th><code>\|</code></th></tr></thead><tbody>
+<tr><td>Double</td><td><code>\|</code></td></tr>
+</tbody></table>
+<table><thead><tr><th>Double Twice</th><th><code>\|\|</code></th></tr></thead><tbody>
+<tr><td>Double Twice</td><td><code>\|\|</code></td></tr>
+</tbody></table>
+<table><thead><tr><th>Triple</th><th><code>\\|</code></th></tr></thead><tbody>
+<tr><td>Triple</td><td><code>\\|</code></td></tr>
+</tbody></table>
+````````````````````````````````

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -812,6 +812,11 @@ impl<'input, 'callback> Parser<'input, 'callback> {
 
             while ix != close {
                 let next_ix = self.tree[ix].next.unwrap();
+                let end = if next_ix == close {
+                    span_end
+                } else {
+                    self.tree[next_ix].item.start
+                };
                 if let ItemBody::HardBreak | ItemBody::SoftBreak = self.tree[ix].item.body {
                     if drop_enclosing_whitespace {
                         // check whether break should be ignored
@@ -838,12 +843,26 @@ impl<'input, 'callback> Parser<'input, 'callback> {
                         new_buf.push(' ');
                         buf = Some(new_buf);
                     }
+                } else if self.tree.is_in_table() && self.text[self.tree[ix].item.start..end].contains("|") {
+                    for (i, c) in bytes[self.tree[ix].item.start..end].into_iter().copied().enumerate() {
+                        if c != b'|' {
+                            continue;
+                        }
+                        let pipe_position = self.tree[ix].item.start + i;
+                        let buf = if let Some(ref mut buf) = buf {
+                            buf.push_str(&self.text[self.tree[ix].item.start..pipe_position]);
+                            buf
+                        } else {
+                            let mut new_buf = String::with_capacity(pipe_position - span_start);
+                            new_buf.push_str(&self.text[span_start..pipe_position]);
+                            buf.insert(new_buf)
+                        };
+                        let ends_in_backslash = buf.as_bytes().last() == Some(&b'\\');
+                        let trim = if ends_in_backslash { 1 } else { 0 };
+                        buf.truncate(buf.len() - trim);
+                        buf.push_str(&self.text[pipe_position..end]);
+                    }
                 } else if let Some(ref mut buf) = buf {
-                    let end = if next_ix == close {
-                        span_end
-                    } else {
-                        self.tree[ix].item.end
-                    };
                     buf.push_str(&self.text[self.tree[ix].item.start..end]);
                 }
                 ix = next_ix;
@@ -952,6 +971,31 @@ impl<'a> Tree<Item> {
                 body: ItemBody::Text,
             });
         }
+    }
+    /// Returns true if the current node is inside a table.
+    ///
+    /// If `cur` is an ItemBody::Table, it would return false,
+    /// but since the `TableRow` and `TableHead` and `TableCell`
+    /// are children of the table, anything doing inline parsing
+    /// doesn't need to care about that.
+    pub(crate) fn is_in_table(&self) -> bool {
+        fn might_be_in_table(item: &Item) -> bool {
+            item.body.is_inline() || matches!(
+                item.body,
+                | ItemBody::TableHead
+                | ItemBody::TableRow
+                | ItemBody::TableCell
+            )
+        }
+        for &ix in self.walk_spine().rev() {
+            if matches!(self[ix].item.body, ItemBody::Table(_)) {
+                return true;
+            }
+            if !might_be_in_table(&self[ix].item) {
+                return false;
+            }
+        }
+        false
     }
 }
 

--- a/tests/suite/gfm_table.rs
+++ b/tests/suite/gfm_table.rs
@@ -68,7 +68,7 @@ fn gfm_table_test_3() {
 </thead>
 <tbody>
 <tr>
-<td>b <code>\|</code> az</td>
+<td>b <code>|</code> az</td>
 </tr>
 <tr>
 <td>b <strong>|</strong> im</td>

--- a/tests/suite/table.rs
+++ b/tests/suite/table.rs
@@ -349,3 +349,89 @@ fn table_test_16() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn table_test_17() {
+    let original = r##"| Description | Test case |
+|-------------|-----------|
+| Single      | `\`       |
+| Double      | `\\`      |
+| Basic test  | `\|`      |
+| Basic test 2| `\|\|\`   |
+| Basic test 3| `x\|y\|z\`|
+| Not pipe    | `\.`      |
+| Combo       | `\.\|\`   |
+| Extra       | `\\\.`    |
+| Wait, what? | `\\|`     |
+| Wait, what? | `\\\|`    |
+| Wait, what? | `\\\\|`   |
+| Wait, what? | `\\\\\|`  |
+| Wait, what? |          \|
+| Wait, what? |         \\|
+| Wait, what? |        \\\|
+| Wait, what?x|          \|x
+| Wait, what?x|         \\|x
+| Wait, what?x|        \\\|x
+"##;
+    let expected = r##"<table><thead><tr><th>Description</th><th>Test case</th></tr></thead><tbody>
+<tr><td>Single</td><td><code>\</code></td></tr>
+<tr><td>Double</td><td><code>\\</code></td></tr>
+<tr><td>Basic test</td><td><code>|</code></td></tr>
+<tr><td>Basic test 2</td><td><code>||\</code></td></tr>
+<tr><td>Basic test 3</td><td><code>x|y|z\</code></td></tr>
+<tr><td>Not pipe</td><td><code>\.</code></td></tr>
+<tr><td>Combo</td><td><code>\.|\</code></td></tr>
+<tr><td>Extra</td><td><code>\\\.</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\|</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\\|</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\\\|</code></td></tr>
+<tr><td>Wait, what?</td><td><code>\\\\|</code></td></tr>
+<tr><td>Wait, what?</td><td>|</td></tr>
+<tr><td>Wait, what?</td><td>|</td></tr>
+<tr><td>Wait, what?</td><td>\|</td></tr>
+<tr><td>Wait, what?x</td><td>|x</td></tr>
+<tr><td>Wait, what?x</td><td>|x</td></tr>
+<tr><td>Wait, what?x</td><td>\|x</td></tr>
+</tbody></table>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn table_test_18() {
+    let original = r##"| Single | `\|` |
+|--|--|
+| Single | `\|` |
+
+
+| Double | `\\|` |
+|--|--|
+| Double | `\\|` |
+
+
+| Double Twice | `\\|\\|` |
+|--|--|
+| Double Twice | `\\|\\|` |
+
+
+| Triple | `\\\|` |
+|--|--|
+| Triple | `\\\|` |
+"##;
+    let expected = r##"<table><thead><tr><th>Single</th><th><code>|</code></th></tr></thead><tbody>
+<tr><td>Single</td><td><code>|</code></td></tr>
+</tbody></table>
+<table><thead><tr><th>Double</th><th><code>\|</code></th></tr></thead><tbody>
+<tr><td>Double</td><td><code>\|</code></td></tr>
+</tbody></table>
+<table><thead><tr><th>Double Twice</th><th><code>\|\|</code></th></tr></thead><tbody>
+<tr><td>Double Twice</td><td><code>\|\|</code></td></tr>
+</tbody></table>
+<table><thead><tr><th>Triple</th><th><code>\\|</code></th></tr></thead><tbody>
+<tr><td>Triple</td><td><code>\\|</code></td></tr>
+</tbody></table>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}

--- a/third_party/GitHub/gfm_table.txt
+++ b/third_party/GitHub/gfm_table.txt
@@ -83,7 +83,7 @@ inline spans:
 </thead>
 <tbody>
 <tr>
-<td>b <code>\|</code> az</td>
+<td>b <code>|</code> az</td>
 </tr>
 <tr>
 <td>b <strong>|</strong> im</td>


### PR DESCRIPTION
Fixes #356

This is an alternative version of https://github.com/raphlinus/pulldown-cmark/pull/691 that follows GitHub's behavior more closely (it gives `\|` higher precedence in the parser than any other backslash escape).

Compare with the rendering in [GitHub].

[GitHub]: https://gist.github.com/notriddle/c027512ee849f12098fec3a3256c89d3