### PR TITLE
Use generics for broken link callback

### DIFF
--- a/examples/broken-link-callbacks.rs
+++ b/examples/broken-link-callbacks.rs
@@ -6,7 +6,7 @@ fn main() {
 
     // Setup callback that sets the URL and title when it encounters
     // a reference to our home page.
-    let callback = &mut |broken_link: BrokenLink| {
+    let callback = |broken_link: BrokenLink| {
         if broken_link.reference.as_ref() == "my website" {
             println!(
                 "Replacing the markdown `{}` of type {:?} with a working link",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,9 @@ mod tree;
 
 use std::{convert::TryFrom, fmt::Display};
 
-pub use crate::parse::{BrokenLink, BrokenLinkCallback, LinkDef, OffsetIter, Parser, RefDefs};
+pub use crate::parse::{
+    BrokenLink, BrokenLinkCallback, DefaultBrokenLinkCallback, OffsetIter, Parser, RefDefs,
+};
 pub use crate::strings::{CowStr, InlineStr};
 pub use crate::utils::*;
 


### PR DESCRIPTION
As discussed in #508, #509 and #697, the current broken link callback API is a little clunky. This PR changes it to use generics instead of dynamic dispatch.

I haven't considered the performance or binary size implications of this. There should be no difference when not using the callback (all instances use `DefaultBrokenLinkCallback`), but when using it, all the parser's methods will be monomorphized somewhat unnecessarily. Ultimately it's up to you (the maintainers) to decide.

On the flip side, this solution provides the most flexible API. `Parser` will now transitively implement `Send` & `Sync` if the callback does. It can also accept `'static` callbacks:

```rust
fn callback<'input>(link: BrokenLink<'input>) -> Option<(CowStr<'input>, CowStr<'input>)> {
    todo!()
}

fn parse(input: &str) -> impl Iterator<Item = Event<'_>> + '_ {
    Parser::new_with_broken_link_callback(input, Options::empty(), Some(callback))
}
```

Some finer details that I'm unsure of:

- `new_with_broken_link_callback` still takes an `Option`, though it could just accept the callback directly. Doing it like this reduces API breakage as the previous signature `Option<&mut dyn FnMut>` is still accepted.
- I chose for `BrokenLinkCallback` to be a trait with a method `handle_broken_link`. It could also be a "trait alias" with an `FnMut` bound so that the separate function name wouldn't be exposed. I feel this makes the no-op `DefaultBrokenLinkCallback` cleaner, but it could also be a function.
- `BrokenLinkCallback` could be more general – if it is decided to add other types of callbacks later, it would be convenient to add them to a broader "`Callback`" trait. In this case the blanket impl for `FnMut` would be questionable though.

Closes #508, #697