### PR TITLE
Fixes `rustdoc::bare_urls` lint

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 //! Miscellaneous utilities to incraese comfort.
 //! Special thanks to
-//! https://github.com/BenjaminRi/Redwood-Wiki/blob/master/src/markdown_utils.rs.
+//! <https://github.com/BenjaminRi/Redwood-Wiki/blob/master/src/markdown_utils.rs>.
 //! Its author authorized the use of this GPL code in this project in
-//! https://github.com/raphlinus/pulldown-cmark/issues/507.
+//! <https://github.com/raphlinus/pulldown-cmark/issues/507>.
 
 use crate::{CowStr, Event};
 


### PR DESCRIPTION
It fixes this:

```
warning: this URL is not a hyperlink
 --> src/utils.rs:3:5
  |
3 | //! https://github.com/BenjaminRi/Redwood-Wiki/blob/master/src/markdown_utils.rs.
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/BenjaminRi/Redwood-Wiki/blob/master/src/markdown_utils.rs.>`
  |
  = note: bare URLs are not automatically turned into clickable links
  = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: this URL is not a hyperlink
 --> src/utils.rs:5:5
  |
5 | //! https://github.com/raphlinus/pulldown-cmark/issues/507.
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/raphlinus/pulldown-cmark/issues/507.>`
  |
  = note: bare URLs are not automatically turned into clickable links

warning: `pulldown-cmark` (lib doc) generated 2 warnings (run `cargo fix --lib -p pulldown-cmark` to apply 2 suggestions)
```