### PR TITLE
Fix elided lifetimes and unused lifetimes errors

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -53,7 +53,7 @@ pub struct WriteWrapper<W>(pub W);
 pub trait StrWrite {
     fn write_str(&mut self, s: &str) -> io::Result<()>;
 
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()>;
+    fn write_fmt(&mut self, args: Arguments<'_>) -> io::Result<()>;
 }
 
 impl<W> StrWrite for WriteWrapper<W>
@@ -66,12 +66,12 @@ where
     }
 
     #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
+    fn write_fmt(&mut self, args: Arguments<'_>) -> io::Result<()> {
         self.0.write_fmt(args)
     }
 }
 
-impl<'w> StrWrite for String {
+impl StrWrite for String {
     #[inline]
     fn write_str(&mut self, s: &str) -> io::Result<()> {
         self.push_str(s);
@@ -79,7 +79,7 @@ impl<'w> StrWrite for String {
     }
 
     #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
+    fn write_fmt(&mut self, args: Arguments<'_>) -> io::Result<()> {
         // FIXME: translate fmt error to io error?
         FmtWrite::write_fmt(self, args).map_err(|_| ErrorKind::Other.into())
     }
@@ -95,7 +95,7 @@ where
     }
 
     #[inline]
-    fn write_fmt(&mut self, args: Arguments) -> io::Result<()> {
+    fn write_fmt(&mut self, args: Arguments<'_>) -> io::Result<()> {
         (**self).write_fmt(args)
     }
 }

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -18,7 +18,7 @@ use unicase::UniCase;
 
 /// Runs the first pass, which resolves the block structure of the document,
 /// and returns the resulting tree.
-pub(crate) fn run_first_pass(text: &str, options: Options) -> (Tree<Item>, Allocations) {
+pub(crate) fn run_first_pass(text: &str, options: Options) -> (Tree<Item>, Allocations<'_>) {
     // This is a very naive heuristic for the number of nodes
     // we'll need.
     let start_capacity = max(128, text.len() / 32);
@@ -1652,7 +1652,7 @@ fn extract_attribute_block_content_from_header_text(
 /// See also: [`Options::ENABLE_HEADING_ATTRIBUTES`].
 ///
 /// [`Options::ENABLE_HEADING_ATTRIBUTES`]: `crate::Options::ENABLE_HEADING_ATTRIBUTES`
-fn parse_inside_attribute_block(inside_attr_block: &str) -> Option<HeadingAttributes> {
+fn parse_inside_attribute_block(inside_attr_block: &str) -> Option<HeadingAttributes<'_>> {
     let mut id = None;
     let mut classes = Vec::new();
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -304,7 +304,7 @@ where
         }
     }
 
-    fn end_tag(&mut self, tag: Tag) -> io::Result<()> {
+    fn end_tag(&mut self, tag: Tag<'_>) -> io::Result<()> {
         match tag {
             Tag::Paragraph => {
                 self.write("</p>\n")?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -102,7 +102,7 @@ pub(crate) enum ItemBody {
     Root,
 }
 
-impl<'a> ItemBody {
+impl ItemBody {
     fn is_inline(&self) -> bool {
         matches!(
             *self,
@@ -117,7 +117,7 @@ impl<'a> ItemBody {
     }
 }
 
-impl<'a> Default for ItemBody {
+impl Default for ItemBody {
     fn default() -> Self {
         ItemBody::Root
     }
@@ -198,7 +198,7 @@ impl<'input, 'callback> Parser<'input, 'callback> {
 
     /// Returns a reference to the internal `RefDefs` object, which provides access
     /// to the internal map of reference definitions.
-    pub fn reference_definitions(&self) -> &RefDefs {
+    pub fn reference_definitions(&self) -> &RefDefs<'_> {
         &self.allocs.refdefs
     }
 
@@ -887,7 +887,7 @@ impl<'input, 'callback> Parser<'input, 'callback> {
 }
 
 /// Returns number of containers scanned.
-pub(crate) fn scan_containers(tree: &Tree<Item>, line_start: &mut LineStart) -> usize {
+pub(crate) fn scan_containers(tree: &Tree<Item>, line_start: &mut LineStart<'_>) -> usize {
     let mut i = 0;
     for &node_ix in tree.walk_spine() {
         match tree[node_ix].item.body {
@@ -911,7 +911,7 @@ pub(crate) fn scan_containers(tree: &Tree<Item>, line_start: &mut LineStart) -> 
     i
 }
 
-impl<'a> Tree<Item> {
+impl Tree<Item> {
     pub(crate) fn append_text(&mut self, start: usize, end: usize) {
         if end > start {
             if let Some(ix) = self.cur() {
@@ -1366,7 +1366,7 @@ pub struct OffsetIter<'a, 'b> {
 
 impl<'a, 'b> OffsetIter<'a, 'b> {
     /// Returns a reference to the internal reference definition tracker.
-    pub fn reference_definitions(&self) -> &RefDefs {
+    pub fn reference_definitions(&self) -> &RefDefs<'_> {
         self.inner.reference_definitions()
     }
 }

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -111,7 +111,7 @@ pub(crate) struct LineStart<'a> {
 }
 
 impl<'a> LineStart<'a> {
-    pub(crate) fn new(bytes: &[u8]) -> LineStart {
+    pub(crate) fn new(bytes: &[u8]) -> LineStart<'_> {
         LineStart {
             bytes,
             tab_start: 0,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -20,7 +20,7 @@ pub struct InlineStr {
     len: u8,
 }
 
-impl<'a> AsRef<str> for InlineStr {
+impl AsRef<str> for InlineStr {
     fn as_ref(&self) -> &str {
         self.deref()
     }
@@ -41,7 +41,7 @@ impl From<char> for InlineStr {
     }
 }
 
-impl<'a> std::cmp::PartialEq<InlineStr> for InlineStr {
+impl std::cmp::PartialEq<InlineStr> for InlineStr {
     fn eq(&self, other: &InlineStr) -> bool {
         self.deref() == other.deref()
     }
@@ -73,7 +73,7 @@ impl Deref for InlineStr {
 }
 
 impl fmt::Display for InlineStr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_ref())
     }
 }
@@ -160,7 +160,7 @@ impl<'a> std::clone::Clone for CowStr<'a> {
 }
 
 impl<'a> std::cmp::PartialEq<CowStr<'a>> for CowStr<'a> {
-    fn eq(&self, other: &CowStr) -> bool {
+    fn eq(&self, other: &CowStr<'_>) -> bool {
         self.deref() == other.deref()
     }
 }
@@ -237,7 +237,7 @@ impl<'a> CowStr<'a> {
 }
 
 impl<'a> fmt::Display for CowStr<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_ref())
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -229,12 +229,12 @@ impl<T> std::fmt::Debug for Tree<T>
 where
     T: std::fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fn debug_tree<T>(
             tree: &Tree<T>,
             cur: TreeIndex,
             indent: usize,
-            f: &mut std::fmt::Formatter,
+            f: &mut std::fmt::Formatter<'_>,
         ) -> std::fmt::Result
         where
             T: std::fmt::Debug,


### PR DESCRIPTION
I'm currently working on something and I had a lot of errors about lifetimes so I decided to send a patch for them.