### PR TITLE
Parse `[^]` as a link

### DIFF
--- a/specs/footnotes.txt
+++ b/specs/footnotes.txt
@@ -542,3 +542,13 @@ Second <sup class="footnote-reference"><a href="#2">2</a></sup> test</p>
 <tr><td>[^4]: test</td><td>test [^4]</td></tr>
 </tbody></table>
 ````````````````````````````````
+
+Footnote labels cannot be empty.
+
+```````````````````````````````` example
+Test [^] link
+
+[^]: https://rust-lang.org
+.
+<p>Test <a href="https://rust-lang.org">^</a> link</p>
+````````````````````````````````

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1206,7 +1206,7 @@ fn scan_link_label<'text, 'tree>(
         let _ = scan_containers(tree, &mut line_start, gfm_footnotes);
         Some(line_start.bytes_scanned())
     };
-    let pair = if allow_footnote_refs && b'^' == bytes[1] {
+    let pair = if allow_footnote_refs && b'^' == bytes[1] && bytes.get(2) != Some(&b']') {
         let (byte_index, cow) = scan_link_label_rest(&text[2..], &linebreak_handler)?;
         (byte_index + 2, ReferenceLabel::Footnote(cow))
     } else {

--- a/tests/suite/footnotes.rs
+++ b/tests/suite/footnotes.rs
@@ -533,3 +533,15 @@ Second <sup class="footnote-reference"><a href="#2">2</a></sup> test</p>
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn footnotes_test_20() {
+    let original = r##"Test [^] link
+
+[^]: https://rust-lang.org
+"##;
+    let expected = r##"<p>Test <a href="https://rust-lang.org">^</a> link</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
This is consistent with most other CommonMark parsers, even when they have support for footnotes turned on.