### PR TITLE
Parse settext headers with higher priority than linkdefs

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1605,3 +1605,14 @@ ISSUE 755
 <tr><td>*<em>#</em></td></tr>
 </tbody></table>
 ````````````````````````````````
+
+ISSUE 768
+
+```````````````````````````````` example
+[First try
+----------
+Second try]: https://rust-lang.org
+.
+<h2>[First try</h2>
+<p>Second try]: https://rust-lang.org</p>
+````````````````````````````````

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -1850,7 +1850,7 @@ fn regression_test_119() {
     let expected = r##"<p>[x\</p>
 <p>]: https://rust-lang.org</p>
 "##;
-  
+
     test_markdown_html(original, expected, false, false, false);
 }
 
@@ -1883,6 +1883,19 @@ fn regression_test_120() {
 <tr><td>*<em>#</em></td></tr>
 </tbody></table>
 "##;
-  
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_121() {
+    let original = r##"[First try
+----------
+Second try]: https://rust-lang.org
+"##;
+    let expected = r##"<h2>[First try</h2>
+<p>Second try]: https://rust-lang.org</p>
+"##;
+
     test_markdown_html(original, expected, false, false, false);
 }


### PR DESCRIPTION
Fixes #768

Consider this:

```markdown
[First try
----------
Second try]: https://rust-lang.org
```

It's a real ambiguity of the CommonMark spec; I could not find anywhere that it said anything about whether link definitions or setext headers have higher binding power. But most other parsers do it the same way:

* [pandoc/commonmark-hs](https://pandoc.org/try/?params=%7B%22text%22%3A%22%5BFirst+try%5Cn----------%5CnSecond+try%5D%3A+https%3A%2F%2Frust-lang.org%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22commonmark%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D)
* [commonmark.js](https://spec.commonmark.org/dingus/?text=%5BFirst%20try%0A----------%0ASecond%20try%5D%3A%20https%3A%2F%2Frust-lang.org)
* [markdown-it](https://markdown-it.github.io/#md3=%7B%22source%22%3A%22%5BFirst%20try%5Cn----------%5CnSecond%20try%5D%3A%20https%3A%2F%2Frust-lang.org%22%2C%22defaults%22%3A%7B%22html%22%3Afalse%2C%22xhtmlOut%22%3Afalse%2C%22breaks%22%3Afalse%2C%22langPrefix%22%3A%22language-%22%2C%22linkify%22%3Atrue%2C%22typographer%22%3Atrue%2C%22_highlight%22%3Atrue%2C%22_strict%22%3Afalse%2C%22_view%22%3A%22html%22%7D%7D)
* and hugo/goldmark