### PR TITLE
Correct instructions for running specs

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1,4 +1,4 @@
-Run this with `cargo run -- -T -F -s specs/regression.txt`.
+Run this with `cargo test --features gen-tests suite::regression`.
 
 Regression tests for issues on the github issue tracker.
 

--- a/specs/table.txt
+++ b/specs/table.txt
@@ -1,4 +1,4 @@
-Run this with `cargo run -- -T -s specs/table.txt`.
+Run this with `cargo test --features gen-tests suite::table`.
 
 Adapted from original by replacing `td` elements by `th` elements inside `thead`
 and disabling the third test.


### PR DESCRIPTION
Running specs with `cargo run -- -s` hasn't worked since 22aea4720f8c9b2ad78b584e710e35e1c5a21e48. Fix the instructions to work with the current harness.