### PR TITLE
Read lazy paragraph continuations off of refdefs

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1702,3 +1702,46 @@ bar \
 <h1>foo \</h1>
 <p>bar \</p>
 ````````````````````````````````
+
+ISSUE 781
+
+```````````````````````````````` example
+- [foo]: test
+bar
+
+> [bar]: test
+[baz]: rstr
+[bar]
+.
+<ul>
+<li>bar</li>
+</ul>
+<blockquote>
+<p><a href="test">bar</a></p>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+> - [foo]: test
+> bar
+> 
+> > [bar]: test
+> [baz]: rstr
+> [bar]
+.
+<blockquote>
+<ul>
+<li>bar</li>
+</ul>
+<blockquote>
+<p><a href="test">bar</a></p>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+[bar]: test
+-
+.
+<p>-</p>
+````````````````````````````````

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -1980,14 +1980,67 @@ fn regression_test_124() {
 
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_125() {
-      let original = r##"# foo \
+    let original = r##"# foo \
 bar \
 "##;
     let expected = r##"<h1>foo \</h1>
 <p>bar \</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_126() {
+    let original = r##"- [foo]: test
+bar
+
+> [bar]: test
+[baz]: rstr
+[bar]
+"##;
+    let expected = r##"<ul>
+<li>bar</li>
+</ul>
+<blockquote>
+<p><a href="test">bar</a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_127() {
+    let original = r##"> - [foo]: test
+> bar
+> 
+> > [bar]: test
+> [baz]: rstr
+> [bar]
+"##;
+    let expected = r##"<blockquote>
+<ul>
+<li>bar</li>
+</ul>
+<blockquote>
+<p><a href="test">bar</a></p>
+</blockquote>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_128() {
+    let original = r##"[bar]: test
+-
+"##;
+    let expected = r##"<p>-</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);


### PR DESCRIPTION
This matches the behavior of [GitHub], [commonmark.js], and [commonmark-hs].

[markdown-it], however, does not treat these as lazy continuations.

It seems like [commonmark-hs's parser] and [commonmark.js's parser] both work by parsing these refdefs as paragraphs first, then pulling out the refdef.

[GitHub]: https://gist.github.com/notriddle/c2498c6afd1bca1a11e23623559ff58a
[commonmark.js]: https://spec.commonmark.org/dingus/?text=%3E%20-%20%5Bfoo%5D%3A%20test%0A%3E%20bar%0A%3E%20%0A%3E%20%3E%20%5Bbar%5D%3A%20test%0A%3E%20%5Bbaz%5D%3A%20rstr%0A%3E%20%5Bbar%5D
[commonmark-hs]: https://pandoc.org/try/?params=%7B%22text%22%3A%22%3E+-+%5Bfoo%5D%3A+test%5Cn%3E+bar%5Cn%3E+%5Cn%3E+%3E+%5Bbar%5D%3A+test%5Cn%3E+%5Bbaz%5D%3A+rstr%5Cn%3E+%5Bbar%5D%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22commonmark_x%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D
[markdown-it]: https://markdown-it.github.io/#md3=%7B%22source%22%3A%22%3E%20-%20%5Bfoo%5D%3A%20test%5Cn%3E%20bar%5Cn%3E%20%5Cn%3E%20%3E%20%5Bbar%5D%3A%20test%5Cn%3E%20%5Bbaz%5D%3A%20rstr%5Cn%3E%20%5Bbar%5D%22%2C%22defaults%22%3A%7B%22html%22%3Afalse%2C%22xhtmlOut%22%3Afalse%2C%22breaks%22%3Afalse%2C%22langPrefix%22%3A%22language-%22%2C%22linkify%22%3Atrue%2C%22typographer%22%3Atrue%2C%22_highlight%22%3Atrue%2C%22_strict%22%3Atrue%2C%22_view%22%3A%22src%22%7D%7D

[commonmark-hs's parser]: https://github.com/jgm/commonmark-hs/blob/6ec393d5c7950b5edd410d448a00344277c971ad/commonmark/src/Commonmark/Blocks.hs#L607
[commonmark.js's parser]: https://github.com/commonmark/commonmark.js/blob/9f548fedcb74b527825078fe31f5748499f2937d/lib/blocks.js#L212