### PR TITLE
Fix incorrect space handling at paragraph/linkref boundary

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1758,3 +1758,56 @@ bar
 .
 <p>-</p>
 ````````````````````````````````
+
+
+```````````````````````````````` example
+[linkme]: foo
+    - baz
+.
+<p>- baz</p>
+````````````````````````````````
+
+https://gist.github.com/notriddle/0048782ad2e819a134c094a1cc52df84
+
+```````````````````````````````` example
+[linkme-3]:
+   [^foo]:
+
+[linkme-4]:
+    [^bar]:
+
+GFM footnotes can interrupt link defs if they have three spaces, but not four.
+.
+<p>[linkme-3]:</p>
+<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
+<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
+````````````````````````````````
+
+```````````````````````````````` example
+[linkme-3]:
+   ===
+
+[linkme-4]:
+    ===
+
+Setext heading can interrupt link def if it has three spaces, but not four.
+.
+<h1>[linkme-3]:</h1>
+<p>Setext heading can interrupt link def if it has three spaces, but not four.</p>
+````````````````````````````````
+
+```````````````````````````````` example
+[linkme-3]: a
+   - a
+
+[linkme-4]: a
+    - b
+
+List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.
+.
+<ul>
+<li>a</li>
+</ul>
+<p>- b</p>
+<p>List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.</p>
+````````````````````````````````

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2003,10 +2003,10 @@ fn regression_test_126() {
     let expected = r##"<h2>[third try]:</h2>
 <p>[third try]</p>
 "##;
-  
+
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_127() {
     let original = r##"- [foo]: test
@@ -2055,6 +2055,72 @@ fn regression_test_129() {
 -
 "##;
     let expected = r##"<p>-</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_130() {
+    let original = r##"[linkme]: foo
+    - baz
+"##;
+    let expected = r##"<p>- baz</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_131() {
+    let original = r##"[linkme-3]:
+   [^foo]:
+
+[linkme-4]:
+    [^bar]:
+
+GFM footnotes can interrupt link defs if they have three spaces, but not four.
+"##;
+    let expected = r##"<p>[linkme-3]:</p>
+<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
+<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_132() {
+    let original = r##"[linkme-3]:
+   ===
+
+[linkme-4]:
+    ===
+
+Setext heading can interrupt link def if it has three spaces, but not four.
+"##;
+    let expected = r##"<h1>[linkme-3]:</h1>
+<p>Setext heading can interrupt link def if it has three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_133() {
+    let original = r##"[linkme-3]: a
+   - a
+
+[linkme-4]: a
+    - b
+
+List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.
+"##;
+    let expected = r##"<ul>
+<li>a</li>
+</ul>
+<p>- b</p>
+<p>List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);


### PR DESCRIPTION
This matches [commonmark.js], [commonmark-hs] and [GitHub].

[commonmark.js]: https://spec.commonmark.org/dingus/?text=%5Blinkme%5D%3A%20foo%0A%20%20%20%20-%20baz
[commonmark-hs]: https://pandoc.org/try/?params=%7B%22text%22%3A%22%5Blinkme%5D%3A+foo%5Cn++++-+baz%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22commonmark%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D
[GitHub]: https://gist.github.com/notriddle/feaa24cc56792e8eb5417c71bcbf8ea7