### PR TITLE
Fix parsing of spaces in code

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -450,7 +450,7 @@ EMPTY CODE IN BLOCKQUOTE
 > `
 .
 <blockquote>
-<p><code></code></p>
+<p><code> </code></p>
 </blockquote>
 ````````````````````````````````
 

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -249,3 +249,37 @@ fn html_test_broken_callback() {
 
     assert_eq!(expected, s);
 }
+
+#[test]
+fn newline_in_code() {
+    let originals = ["`\n `x", "` \n`x"];
+    let expected = "<p><code>  </code>x</p>\n";
+
+    for original in originals {
+        let mut s = String::new();
+        html::push_html(&mut s, Parser::new(&original));
+        assert_eq!(expected, s);
+    }
+}
+
+#[test]
+fn newline_start_end_of_code() {
+    let original = "`\nx\n`x";
+    let expected = "<p><code>x</code>x</p>\n";
+
+    let mut s = String::new();
+    html::push_html(&mut s, Parser::new(&original));
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn newline_within_code() {
+    let originals = ["`\nx \ny\n`x", "`x \ny`x", "`x\n y`x"];
+    let expected = "<p><code>x  y</code>x</p>\n";
+
+    for original in originals {
+        let mut s = String::new();
+        html::push_html(&mut s, Parser::new(&original));
+        assert_eq!(expected, s);
+    }
+}

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -530,7 +530,7 @@ fn regression_test_39() {
 > `
 "##;
     let expected = r##"<blockquote>
-<p><code></code></p>
+<p><code> </code></p>
 </blockquote>
 "##;
 
@@ -2073,23 +2073,12 @@ foo)
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
-  
+
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_131() {
-    let original = r##"[linkme]: foo
-    - baz
-"##;
-    let expected = r##"<p>- baz</p>
-"##;
-
-    test_markdown_html(original, expected, false, false, false);
-}
-
-#[test]
-fn regression_test_132() {
     let original = r##"[link](foo
 )
 
@@ -2101,30 +2090,12 @@ fn regression_test_132() {
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
- 
-  test_markdown_html(original, expected, false, false, false);
-}
-  
-  #[test]
-fn regression_test_133() {
-    let original = r##"[linkme-3]:
-   [^foo]:
-
-[linkme-4]:
-    [^bar]:
-
-GFM footnotes can interrupt link defs if they have three spaces, but not four.
-"##;
-    let expected = r##"<p>[linkme-3]:</p>
-<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
-<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
-"##;
 
     test_markdown_html(original, expected, false, false, false);
 }
 
 #[test]
-fn regression_test_134() {
+fn regression_test_132() {
     let original = r##"[link](foo
 "bar"
 )
@@ -2142,8 +2113,58 @@ fn regression_test_134() {
     test_markdown_html(original, expected, false, false, false);
 }
 
-  #[test]
+#[test]
+fn regression_test_133() {
+    let original = r##"[link](	
+	foo	
+	"bar"	
+	)
+
+> [link](	
+> 	foo	
+> 	"bar"	
+> 	)
+"##;
+    let expected = r##"<p><a href="foo" title="bar">link</a></p>
+<blockquote>
+<p><a href="foo" title="bar">link</a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_134() {
+    let original = r##"[linkme]: foo
+    - baz
+"##;
+    let expected = r##"<p>- baz</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
 fn regression_test_135() {
+    let original = r##"[linkme-3]:
+   [^foo]:
+
+[linkme-4]:
+    [^bar]:
+
+GFM footnotes can interrupt link defs if they have three spaces, but not four.
+"##;
+    let expected = r##"<p>[linkme-3]:</p>
+<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
+<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_136() {
     let original = r##"[linkme-3]:
    ===
 
@@ -2160,7 +2181,7 @@ Setext heading can interrupt link def if it has three spaces, but not four.
 }
 
 #[test]
-fn regression_test_136() {
+fn regression_test_137() {
     let original = r##"[linkme-3]: a
    - a
 


### PR DESCRIPTION
Fixes #661

The changed case in regression.txt actually aligns our behavior with [commonmark.js](https://spec.commonmark.org/dingus/?text=%3E%20%60%0A%3E%20%60&smart=1). Check the "HTML" tab.

This change simplifies everything by having the code span maker read the text directly, instead of deciphering the tree with all the emphasis data and trimmed spaces (that still gets used if it later finds out that MaybeCode isn't code).