### PR TITLE
Allow setext headers to interrupt link def insides

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1901,3 +1901,87 @@ second]
 -
 second</a></p>
 ````````````````````````````````
+
+```````````````````````````````` example
+[first]: https://example.com
+"
+-
+"
+
+[first]
+.
+<h2>"</h2>
+<p>"</p>
+<p><a href="https://example.com">first</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[first]: https://example.com
+"
+    -
+"
+
+[first]
+.
+<p><a href="https://example.com" title="
+-
+">first</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+> [first]: https://example.com
+> "
+> -
+> "
+>
+> [first]
+.
+<blockquote>
+<h2>"</h2>
+<p>"</p>
+<p><a href="https://example.com">first</a></p>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+> [first]: https://example.com
+> "
+>     -
+> "
+>
+> [first]
+.
+<blockquote>
+<p><a href="https://example.com" title="
+-
+">first</a></p>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+[first]: https://example.com
+"
+\
+"
+
+[first]
+.
+<p><a href="https://example.com" title="
+\
+">first</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[first]: https://example.com
+"
+\
+
+"
+
+[first]
+.
+<p>"
+\</p>
+<p>"</p>
+<p><a href="https://example.com">first</a></p>
+````````````````````````````````

--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1870,3 +1870,34 @@ List can interrupt the paragraph at the start of a link definition if it starts 
 <p>- b</p>
 <p>List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.</p>
 ````````````````````````````````
+
+ISSUE 789
+
+```````````````````````````````` example
+[first
+-
+second]: https://example.com
+
+[first
+-
+second]
+.
+<h2>[first</h2>
+<p>second]: https://example.com</p>
+<h2>[first</h2>
+<p>second]</p>
+````````````````````````````````
+
+```````````````````````````````` example
+[first
+    -
+second]: https://example.com
+
+[first
+    -
+second]
+.
+<p><a href="https://example.com">first
+-
+second</a></p>
+````````````````````````````````

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -1393,9 +1393,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
                 &mut line_start,
                 self.options.has_gfm_footnotes(),
             ) == self.tree.spine_len();
+            if line_start.scan_space(4) {
+                return Some(line_start.bytes_scanned());
+            }
             let bytes_scanned = line_start.bytes_scanned();
             let suffix = &bytes[bytes_scanned..];
-            if self.scan_paragraph_interrupt(suffix, current_container) {
+            if self.scan_paragraph_interrupt(suffix, current_container) || (current_container && scan_setext_heading(suffix).is_some()) {
                 None
             } else {
                 Some(bytes_scanned)

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2236,3 +2236,111 @@ second</a></p>
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_140() {
+    let original = r##"[first]: https://example.com
+"
+-
+"
+
+[first]
+"##;
+    let expected = r##"<h2>"</h2>
+<p>"</p>
+<p><a href="https://example.com">first</a></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_141() {
+    let original = r##"[first]: https://example.com
+"
+    -
+"
+
+[first]
+"##;
+    let expected = r##"<p><a href="https://example.com" title="
+-
+">first</a></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_142() {
+    let original = r##"> [first]: https://example.com
+> "
+> -
+> "
+>
+> [first]
+"##;
+    let expected = r##"<blockquote>
+<h2>"</h2>
+<p>"</p>
+<p><a href="https://example.com">first</a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_143() {
+    let original = r##"> [first]: https://example.com
+> "
+>     -
+> "
+>
+> [first]
+"##;
+    let expected = r##"<blockquote>
+<p><a href="https://example.com" title="
+-
+">first</a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_144() {
+    let original = r##"[first]: https://example.com
+"
+\
+"
+
+[first]
+"##;
+    let expected = r##"<p><a href="https://example.com" title="
+\
+">first</a></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_145() {
+    let original = r##"[first]: https://example.com
+"
+\
+
+"
+
+[first]
+"##;
+    let expected = r##"<p>"
+\</p>
+<p>"</p>
+<p><a href="https://example.com">first</a></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2073,23 +2073,12 @@ foo)
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
-  
+
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_131() {
-    let original = r##"[linkme]: foo
-    - baz
-"##;
-    let expected = r##"<p>- baz</p>
-"##;
-
-    test_markdown_html(original, expected, false, false, false);
-}
-
-#[test]
-fn regression_test_132() {
     let original = r##"[link](foo
 )
 
@@ -2101,30 +2090,12 @@ fn regression_test_132() {
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
- 
-  test_markdown_html(original, expected, false, false, false);
-}
-  
-  #[test]
-fn regression_test_133() {
-    let original = r##"[linkme-3]:
-   [^foo]:
-
-[linkme-4]:
-    [^bar]:
-
-GFM footnotes can interrupt link defs if they have three spaces, but not four.
-"##;
-    let expected = r##"<p>[linkme-3]:</p>
-<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
-<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
-"##;
 
     test_markdown_html(original, expected, false, false, false);
 }
 
 #[test]
-fn regression_test_134() {
+fn regression_test_132() {
     let original = r##"[link](foo
 "bar"
 )
@@ -2142,8 +2113,58 @@ fn regression_test_134() {
     test_markdown_html(original, expected, false, false, false);
 }
 
-  #[test]
+#[test]
+fn regression_test_133() {
+    let original = r##"[link](	
+	foo	
+	"bar"	
+	)
+
+> [link](	
+> 	foo	
+> 	"bar"	
+> 	)
+"##;
+    let expected = r##"<p><a href="foo" title="bar">link</a></p>
+<blockquote>
+<p><a href="foo" title="bar">link</a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_134() {
+    let original = r##"[linkme]: foo
+    - baz
+"##;
+    let expected = r##"<p>- baz</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
 fn regression_test_135() {
+    let original = r##"[linkme-3]:
+   [^foo]:
+
+[linkme-4]:
+    [^bar]:
+
+GFM footnotes can interrupt link defs if they have three spaces, but not four.
+"##;
+    let expected = r##"<p>[linkme-3]:</p>
+<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
+<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_136() {
     let original = r##"[linkme-3]:
    ===
 
@@ -2160,7 +2181,7 @@ Setext heading can interrupt link def if it has three spaces, but not four.
 }
 
 #[test]
-fn regression_test_136() {
+fn regression_test_137() {
     let original = r##"[linkme-3]: a
    - a
 
@@ -2174,6 +2195,43 @@ List can interrupt the paragraph at the start of a link definition if it starts 
 </ul>
 <p>- b</p>
 <p>List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_138() {
+    let original = r##"[first
+-
+second]: https://example.com
+
+[first
+-
+second]
+"##;
+    let expected = r##"<h2>[first</h2>
+<p>second]: https://example.com</p>
+<h2>[first</h2>
+<p>second]</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_139() {
+    let original = r##"[first
+    -
+second]: https://example.com
+
+[first
+    -
+second]
+"##;
+    let expected = r##"<p><a href="https://example.com">first
+-
+second</a></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);


### PR DESCRIPTION
Fixes #789

This is the same parse result from [commonmark.js], [commonmark-hs], [markdown-it], and [GitHub].

[commonmark.js]: https://spec.commonmark.org/dingus/?text=%5Bfirst%0A-%0Asecond%5D%3A%20https%3A%2F%2Fexample.com%0A%0A%5Bfirst%0A-%0Asecond%5D
[commonmark-hs]: https://pandoc.org/try/?params=%7B%22text%22%3A%22%5Bfirst%5Cn-%5Cnsecond%5D%3A+https%3A%2F%2Fexample.com%5Cn%5Cn%5Bfirst%5Cn-%5Cnsecond%5D%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22commonmark%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D
[markdown-it]: https://markdown-it.github.io/#md3=%7B%22source%22%3A%22%5Bfirst%5Cn-%5Cnsecond%5D%3A%20https%3A%2F%2Fexample.com%5Cn%5Cn%5Bfirst%5Cn-%5Cnsecond%5D%22%2C%22defaults%22%3A%7B%22html%22%3Afalse%2C%22xhtmlOut%22%3Afalse%2C%22breaks%22%3Afalse%2C%22langPrefix%22%3A%22language-%22%2C%22linkify%22%3Atrue%2C%22typographer%22%3Atrue%2C%22_highlight%22%3Atrue%2C%22_strict%22%3Afalse%2C%22_view%22%3A%22html%22%7D%7D
[GitHub]: https://gist.github.com/notriddle/312e9c855d0c822d56b25fe604c04eae