### PR TITLE
Avoid updating linkdef when title isn't followed by NL

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1879,3 +1879,15 @@ ISSUE 791
 .
 <p>'<a href="https://example.com">foo</a>'bar</p>
 ````````````````````````````````
+
+```````````````````````````````` example
+- [foo]: https://example.com
+'[foo]'
+[foo]
+.
+<ul>
+<li>
+<a href="https://example.com" title="[foo]">foo</a>
+</li>
+</ul>
+````````````````````````````````

--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1870,3 +1870,12 @@ List can interrupt the paragraph at the start of a link definition if it starts 
 <p>- b</p>
 <p>List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.</p>
 ````````````````````````````````
+
+ISSUE 791
+
+```````````````````````````````` example
+[foo]: https://example.com
+'[foo]'bar
+.
+<p>'<a href="https://example.com">foo</a>'bar</p>
+````````````````````````````````

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -1499,8 +1499,8 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         if let Some((title_length, title)) = scan_refdef_title(&self.text[i..]) {
             // scan EOL
             i += title_length;
-            if let Some(bytes) = scan_blank_line(&bytes[i..]) {
-                backup.0 = i + bytes - start;
+            if scan_blank_line(&bytes[i..]).is_some() {
+                backup.0 = i - start;
                 backup.1.span = span_start..i;
                 backup.1.title = Some(unescape(title));
                 return Some(backup);

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -1497,20 +1497,16 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         // scan title
         // if this fails but newline == 1, return also a refdef without title
         if let Some((title_length, title)) = scan_refdef_title(&self.text[i..]) {
+            // scan EOL
             i += title_length;
-            backup.1.span = span_start..i;
-            backup.1.title = Some(unescape(title));
-        } else if newlines > 0 {
-            return Some(backup);
-        } else {
-            return None;
-        };
-
-        // scan EOL
-        if let Some(bytes) = scan_blank_line(&bytes[i..]) {
-            backup.0 = i + bytes - start;
-            Some(backup)
-        } else if newlines > 0 {
+            if let Some(bytes) = scan_blank_line(&bytes[i..]) {
+                backup.0 = i + bytes - start;
+                backup.1.span = span_start..i;
+                backup.1.title = Some(unescape(title));
+                return Some(backup);
+            }
+        }
+        if newlines > 0 {
             Some(backup)
         } else {
             None

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2210,3 +2210,19 @@ fn regression_test_138() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_139() {
+    let original = r##"- [foo]: https://example.com
+'[foo]'
+[foo]
+"##;
+    let expected = r##"<ul>
+<li>
+<a href="https://example.com" title="[foo]">foo</a>
+</li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2073,23 +2073,12 @@ foo)
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
-  
+
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_131() {
-    let original = r##"[linkme]: foo
-    - baz
-"##;
-    let expected = r##"<p>- baz</p>
-"##;
-
-    test_markdown_html(original, expected, false, false, false);
-}
-
-#[test]
-fn regression_test_132() {
     let original = r##"[link](foo
 )
 
@@ -2101,30 +2090,12 @@ fn regression_test_132() {
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
- 
-  test_markdown_html(original, expected, false, false, false);
-}
-  
-  #[test]
-fn regression_test_133() {
-    let original = r##"[linkme-3]:
-   [^foo]:
-
-[linkme-4]:
-    [^bar]:
-
-GFM footnotes can interrupt link defs if they have three spaces, but not four.
-"##;
-    let expected = r##"<p>[linkme-3]:</p>
-<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
-<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
-"##;
 
     test_markdown_html(original, expected, false, false, false);
 }
 
 #[test]
-fn regression_test_134() {
+fn regression_test_132() {
     let original = r##"[link](foo
 "bar"
 )
@@ -2142,8 +2113,58 @@ fn regression_test_134() {
     test_markdown_html(original, expected, false, false, false);
 }
 
-  #[test]
+#[test]
+fn regression_test_133() {
+    let original = r##"[link](	
+	foo	
+	"bar"	
+	)
+
+> [link](	
+> 	foo	
+> 	"bar"	
+> 	)
+"##;
+    let expected = r##"<p><a href="foo" title="bar">link</a></p>
+<blockquote>
+<p><a href="foo" title="bar">link</a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_134() {
+    let original = r##"[linkme]: foo
+    - baz
+"##;
+    let expected = r##"<p>- baz</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
 fn regression_test_135() {
+    let original = r##"[linkme-3]:
+   [^foo]:
+
+[linkme-4]:
+    [^bar]:
+
+GFM footnotes can interrupt link defs if they have three spaces, but not four.
+"##;
+    let expected = r##"<p>[linkme-3]:</p>
+<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
+<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_136() {
     let original = r##"[linkme-3]:
    ===
 
@@ -2160,7 +2181,7 @@ Setext heading can interrupt link def if it has three spaces, but not four.
 }
 
 #[test]
-fn regression_test_136() {
+fn regression_test_137() {
     let original = r##"[linkme-3]: a
    - a
 
@@ -2174,6 +2195,17 @@ List can interrupt the paragraph at the start of a link definition if it starts 
 </ul>
 <p>- b</p>
 <p>List can interrupt the paragraph at the start of a link definition if it starts with three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_138() {
+    let original = r##"[foo]: https://example.com
+'[foo]'bar
+"##;
+    let expected = r##"<p>'<a href="https://example.com">foo</a>'bar</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);


### PR DESCRIPTION
The quoted text '[foo]' should either be treated as a paragraph, or as a title attribute. The reference implementation thinks it's just text, not a title. But pulldown-cmark treated it as both, generating `<p>'<a href="https://example.com" title="[foo]">foo</a>'bar</p>`, which is definitely wrong.

Fixes #791