### PR TITLE
Trim spaces off start and end of link reference

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -1985,3 +1985,17 @@ second</a></p>
 <p>"</p>
 <p><a href="https://example.com">first</a></p>
 ````````````````````````````````
+
+ISSUE 793
+
+```````````````````````````````` example
+[
+a]: https://example.com
+
+[b
+]: https://example.com
+
+[a] [b]
+.
+<p><a href="https://example.com">a</a> <a href="https://example.com">b</a></p>
+````````````````````````````````

--- a/src/linklabel.rs
+++ b/src/linklabel.rs
@@ -108,9 +108,16 @@ pub(crate) fn scan_link_label_rest<'t>(
         None
     } else {
         let cow = if mark == 0 {
-            text[..ix].into()
+            let asciiws = &[' ', '\r', '\n', '\t'][..];
+            text[..ix].trim_matches(asciiws).into()
         } else {
             label.push_str(&text[mark..ix]);
+            while matches!(label.as_bytes().last(), Some(&b' ' | &b'\r' | &b'\n' | &b'\t')) {
+                label.pop();
+            }
+            while matches!(label.as_bytes().first(), Some(&b' ' | &b'\r' | &b'\n' | &b'\t')) {
+                label.remove(0);
+            }
             label.into()
         };
         Some((ix + 1, cow))

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2344,3 +2344,19 @@ fn regression_test_145() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_146() {
+    let original = r##"[
+a]: https://example.com
+
+[b
+]: https://example.com
+
+[a] [b]
+"##;
+    let expected = r##"<p><a href="https://example.com">a</a> <a href="https://example.com">b</a></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
Fixes #793

This is specifically called out by [the spec]:

> One label matches another just in case their normalized forms are equal. To normalize a label, strip off the opening and closing brackets, perform the Unicode case fold, **strip leading and trailing spaces, tabs, and line endings**, and collapse consecutive internal spaces, tabs, and line endings to a single space. If there are multiple matching reference link definitions, the one that comes first in the document is used. (It is desirable in such cases to emit a warning.)

[the spec]: https://spec.commonmark.org/0.30/#matches