### PR TITLE
Add text generation via `text` feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-target
+target/
 
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "bitflags 2.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark"
-version = "0.9.2"
+version = "0.10.0"
 authors = [
     "Raph Levien <raph.levien@gmail.com>",
     "Marcus Klaas de Vries <mail@marcusklaas.nl>",
@@ -86,3 +86,5 @@ default = ["getopts", "html"]
 gen-tests = []
 simd = []
 html = []
+text = []
+

--- a/src/html.rs
+++ b/src/html.rs
@@ -332,7 +332,7 @@ where
                 } else {
                     self.write("\n<div class=\"footnote-definition\" id=\"")?;
                 }
-                escape_html(&mut self.writer, &*name)?;
+                escape_html(&mut self.writer, &name)?;
                 self.write("\"><sup class=\"footnote-definition-label\">")?;
                 let len = self.numbers.len() + 1;
                 let number = *self.numbers.entry(name).or_insert(len);
@@ -507,7 +507,7 @@ where
 /// let mut bytes = Vec::new();
 /// let parser = Parser::new(markdown_str);
 ///
-/// html::write_html(Cursor::new(&mut bytes), parser);
+/// let _ = html::write_html(Cursor::new(&mut bytes), parser);
 ///
 /// assert_eq!(&String::from_utf8_lossy(&bytes)[..], r#"<h1>hello</h1>
 /// <ul>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,14 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "html")]
+#[cfg(any(feature = "html", feature = "text"))]
 pub mod escape;
+
 #[cfg(feature = "html")]
 pub mod html;
+
+#[cfg(feature = "text")]
+pub mod text;
 
 pub mod utils;
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,193 @@
+//! Text renderer that takes an iterator of events as input.
+
+use std::io::{self, Write};
+
+use crate::escape::{escape_href, StrWrite, WriteWrapper};
+use crate::Event::*;
+use crate::{Event, Tag, TagEnd};
+
+struct TextWriter<I, W> {
+    /// Iterator supplying events.
+    iter: I,
+
+    /// Writer to write to.
+    writer: W,
+
+    /// Whether if inside a block  where text should not be written
+    in_non_writing_block: bool,
+
+    /// How many characters on the current line
+    chars_on_line: usize,
+}
+
+impl<'a, I, W> TextWriter<I, W>
+where
+    I: Iterator<Item = Event<'a>>,
+    W: StrWrite,
+{
+    fn new(iter: I, writer: W) -> Self {
+        Self {
+            iter,
+            writer,
+            in_non_writing_block: false,
+            chars_on_line: 0,
+        }
+    }
+
+    /// Writes a new line.
+    #[inline(always)]
+    fn write_newline(&mut self) -> io::Result<()> {
+        self.writer.write_str("\n")?;
+        self.chars_on_line = 0;
+        Ok(())
+    }
+
+    /// Writes a buffer.
+    #[inline(always)]
+    fn write(&mut self, s: &str) -> io::Result<()> {
+        self.writer.write_str(s)?;
+        if s.ends_with('\n') {
+            self.chars_on_line = 0;
+        } else {
+            self.chars_on_line += s.len();
+        }
+        Ok(())
+    }
+
+    /// Write a separator, if there is text on the line
+    #[inline(always)]
+    fn write_separator(&mut self) -> io::Result<()> {
+        if self.chars_on_line != 0 {
+            self.writer.write_str(" ")?;
+            self.chars_on_line += 1;
+        }
+        Ok(())
+    }
+
+    fn run(mut self) -> io::Result<()> {
+        while let Some(event) = self.iter.next() {
+            match event {
+                Start(tag) => match tag {
+                    Tag::Link {
+                        dest_url, title, ..
+                    } => {
+                        self.write(&title)?;
+                        self.write(": ")?;
+                        escape_href(&mut self.writer, &dest_url)?;
+                        self.in_non_writing_block = true;
+                    }
+                    Tag::FootnoteDefinition(_name) => self.in_non_writing_block = true,
+                    Tag::MetadataBlock(_kind) => self.in_non_writing_block = true,
+                    _ => {}
+                },
+                End(tag) => match tag {
+                    TagEnd::Paragraph
+                    | TagEnd::Heading(_)
+                    | TagEnd::BlockQuote
+                    | TagEnd::Item
+                    | TagEnd::Table
+                    | TagEnd::TableHead
+                    | TagEnd::TableRow => self.write_newline()?,
+                    TagEnd::Link | TagEnd::FootnoteDefinition => self.in_non_writing_block = false,
+                    TagEnd::MetadataBlock(_kind) => self.in_non_writing_block = false,
+                    _ => {}
+                },
+                Text(text) => {
+                    if !self.in_non_writing_block {
+                        self.write_separator()?;
+                        self.write(&text)?;
+                    }
+                }
+                Code(text) => {
+                    self.write_separator()?;
+                    self.write(&text)?;
+                }
+                Html(html) | InlineHtml(html) => {
+                    self.write_separator()?;
+                    self.write(&html)?;
+                }
+                SoftBreak => {
+                    self.write_newline()?;
+                }
+                HardBreak => {
+                    self.write_newline()?;
+                }
+                Rule => {}
+                FootnoteReference(_name) => {}
+                TaskListMarker(_bool) => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Iterate over an `Iterator` of `Event`s, generate text for each `Event`, and
+/// push it to a `String`.
+///
+/// # Examples
+///
+/// ```
+/// use pulldown_cmark::{text, Parser};
+///
+/// let markdown_str = r#"
+/// hello
+/// =====
+///
+/// * alpha
+/// * beta
+/// "#;
+/// let parser = Parser::new(markdown_str);
+///
+/// let mut text_buf = String::new();
+/// text::push_text(&mut text_buf, parser);
+///
+/// assert_eq!(text_buf, r#"hello
+/// alpha
+/// beta
+/// "#);
+/// ```
+pub fn push_text<'a, I>(s: &mut String, iter: I)
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    TextWriter::new(iter, s).run().unwrap();
+}
+
+/// Iterate over an `Iterator` of `Event`s, generate text for each `Event`, and
+/// write it out to a writable stream.
+///
+/// **Note**: using this function with an unbuffered writer like a file or socket
+/// will result in poor performance. Wrap these in a
+/// [`BufWriter`](https://doc.rust-lang.org/std/io/struct.BufWriter.html) to
+/// prevent unnecessary slowdowns.
+///
+/// # Examples
+///
+/// ```
+/// use pulldown_cmark::{text, Parser};
+/// use std::io::Cursor;
+///
+/// let markdown_str = r#"
+/// hello
+/// =====
+///
+/// * alpha
+/// * beta
+/// "#;
+/// let mut bytes = Vec::new();
+/// let parser = Parser::new(markdown_str);
+///
+/// let _ = text::write_text(Cursor::new(&mut bytes), parser);
+///
+/// assert_eq!(&String::from_utf8_lossy(&bytes)[..], r#"hello
+/// alpha
+/// beta
+/// "#);
+/// ```
+pub fn write_text<'a, I, W>(writer: W, iter: I) -> io::Result<()>
+where
+    I: Iterator<Item = Event<'a>>,
+    W: Write,
+{
+    TextWriter::new(iter, WriteWrapper(writer)).run()
+}

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2073,23 +2073,12 @@ foo)
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
-  
+
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_131() {
-    let original = r##"[linkme]: foo
-    - baz
-"##;
-    let expected = r##"<p>- baz</p>
-"##;
-
-    test_markdown_html(original, expected, false, false, false);
-}
-
-#[test]
-fn regression_test_132() {
     let original = r##"[link](foo
 )
 
@@ -2101,30 +2090,12 @@ fn regression_test_132() {
 <p><a href="foo">link</a></p>
 </blockquote>
 "##;
- 
-  test_markdown_html(original, expected, false, false, false);
-}
-  
-  #[test]
-fn regression_test_133() {
-    let original = r##"[linkme-3]:
-   [^foo]:
-
-[linkme-4]:
-    [^bar]:
-
-GFM footnotes can interrupt link defs if they have three spaces, but not four.
-"##;
-    let expected = r##"<p>[linkme-3]:</p>
-<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
-<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
-"##;
 
     test_markdown_html(original, expected, false, false, false);
 }
 
 #[test]
-fn regression_test_134() {
+fn regression_test_132() {
     let original = r##"[link](foo
 "bar"
 )
@@ -2142,8 +2113,58 @@ fn regression_test_134() {
     test_markdown_html(original, expected, false, false, false);
 }
 
-  #[test]
+#[test]
+fn regression_test_133() {
+    let original = r##"[link](	
+	foo	
+	"bar"	
+	)
+
+> [link](	
+> 	foo	
+> 	"bar"	
+> 	)
+"##;
+    let expected = r##"<p><a href="foo" title="bar">link</a></p>
+<blockquote>
+<p><a href="foo" title="bar">link</a></p>
+</blockquote>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_134() {
+    let original = r##"[linkme]: foo
+    - baz
+"##;
+    let expected = r##"<p>- baz</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
 fn regression_test_135() {
+    let original = r##"[linkme-3]:
+   [^foo]:
+
+[linkme-4]:
+    [^bar]:
+
+GFM footnotes can interrupt link defs if they have three spaces, but not four.
+"##;
+    let expected = r##"<p>[linkme-3]:</p>
+<div class="footnote-definition" id="foo"><sup class="footnote-definition-label">1</sup></div>
+<p>GFM footnotes can interrupt link defs if they have three spaces, but not four.</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_136() {
     let original = r##"[linkme-3]:
    ===
 
@@ -2160,7 +2181,7 @@ Setext heading can interrupt link def if it has three spaces, but not four.
 }
 
 #[test]
-fn regression_test_136() {
+fn regression_test_137() {
     let original = r##"[linkme-3]: a
    - a
 

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -1,10 +1,9 @@
-// Tests for HTML spec.
-#![cfg(feature = "html")]
+#![cfg(feature = "text")]
 
-use pulldown_cmark::{html, BrokenLink, Options, Parser};
+use pulldown_cmark::{text, BrokenLink, Options, Parser};
 
 #[test]
-fn html_test_1() {
+fn text_test_1() {
     let original = r##"Little header
 
 <script type="text/js">
@@ -17,7 +16,7 @@ function another_func() {
 console.log("fooooo");
 }
 </script>"##;
-    let expected = r##"<p>Little header</p>
+    let expected = r##"Little header
 <script type="text/js">
 function some_func() {
 console.log("teeeest");
@@ -30,12 +29,12 @@ console.log("fooooo");
 </script>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_2() {
+fn text_test_2() {
     let original = r##"Little header
 
 <script
@@ -49,7 +48,7 @@ function another_func() {
 console.log("fooooo");
 }
 </script>"##;
-    let expected = r##"<p>Little header</p>
+    let expected = r##"Little header
 <script
 type="text/js">
 function some_func() {
@@ -63,86 +62,86 @@ console.log("fooooo");
 </script>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_3() {
+fn test_test_3() {
     let original = r##"Little header
 
 <?
 <div></div>
 <p>Useless</p>
 ?>"##;
-    let expected = r##"<p>Little header</p>
+    let expected = r##"Little header
 <?
 <div></div>
 <p>Useless</p>
 ?>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_4() {
+fn text_test_4() {
     let original = r##"Little header
 
 <!--
 <div></div>
 <p>Useless</p>
 -->"##;
-    let expected = r##"<p>Little header</p>
+    let expected = r##"Little header
 <!--
 <div></div>
 <p>Useless</p>
 -->"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_5() {
+fn text_test_5() {
     let original = r##"Little header
 
 <![CDATA[
 <div></div>
 <p>Useless</p>
 ]]>"##;
-    let expected = r##"<p>Little header</p>
+    let expected = r##"Little header
 <![CDATA[
 <div></div>
 <p>Useless</p>
 ]]>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_6() {
+fn text_test_6() {
     let original = r##"Little header
 
 <!X
 Some things are here...
 >"##;
-    let expected = r##"<p>Little header</p>
+    let expected = r##"Little header
 <!X
 Some things are here...
 >"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_7() {
+fn text_test_7() {
     let original = r##"Little header
 -----------
 
@@ -156,7 +155,7 @@ function another_func() {
 console.log("fooooo");
 }
 </script>"##;
-    let expected = r##"<h2>Little header</h2>
+    let expected = r##"Little header
 <script>
 function some_func() {
 console.log("teeeest");
@@ -169,57 +168,58 @@ console.log("fooooo");
 </script>"##;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_8() {
+fn text_test_8() {
     let original = "A | B\n---|---\nfoo | bar";
-    let expected = r##"<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody>
-<tr><td>foo</td><td>bar</td></tr>
-</tbody></table>
+    let expected = r##"A B
+foo bar
+
 "##;
 
     let mut s = String::new();
     let mut opts = Options::empty();
     opts.insert(Options::ENABLE_TABLES);
-    html::push_html(&mut s, Parser::new_ext(original, opts));
+    text::push_text(&mut s, Parser::new_ext(original, opts));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_9() {
+fn text_test_9() {
     let original = "---";
-    let expected = "<hr />\n";
+    let expected = "";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_10() {
+fn text_test_10() {
     let original = "* * *";
-    let expected = "<hr />\n";
+    let expected = "";
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_11() {
+fn text_test_11() {
     let original = "hi ~~no~~";
-    let expected = "<p>hi ~~no~~</p>\n";
+    let expected = r#"hi ~~no~~
+"#;
 
     let mut s = String::new();
-    html::push_html(&mut s, Parser::new(original));
+    text::push_text(&mut s, Parser::new(original));
     assert_eq!(expected, s);
 }
 
 #[test]
-fn html_test_broken_callback() {
+fn text_test_broken_callback() {
     let original = r##"[foo],
 [bar],
 [baz],
@@ -227,12 +227,12 @@ fn html_test_broken_callback() {
    [baz]: https://example.org
 "##;
 
-    let expected = r##"<p><a href="https://replaced.example.org" title="some title">foo</a>,
-[bar],
-<a href="https://example.org">baz</a>,</p>
+    let expected = r##"some title: https://replaced.example.org ,
+[ bar ] ,
+: https://example.org ,
 "##;
 
-    use pulldown_cmark::{html, Options, Parser};
+    use pulldown_cmark::{text, Options, Parser};
 
     let mut s = String::new();
 
@@ -245,7 +245,7 @@ fn html_test_broken_callback() {
     };
 
     let p = Parser::new_with_broken_link_callback(original, Options::empty(), Some(&mut callback));
-    html::push_html(&mut s, p);
+    text::push_text(&mut s, p);
 
     assert_eq!(expected, s);
 }


### PR DESCRIPTION
This PR provides basic plain-text generation via a new `text` feature, which is disabled by default.

I added this as I needed to send e-mail content which is best sent as a multipart message containing both HTML and plain text and markdown seemed like the best format for this.

One issue with generating multiple strings from the same markdown input is that it's necessary to duplicate the parser as the iterator consumes the input:

```
let text_content = {
    let pulldown_parser = Parser::new(&markdown_content);
    let mut text_content = String::new();
    text::push_text(&mut text_content, pulldown_parser);
    text_content
};

let html_content = {
    let pulldown_parser = Parser::new(&markdown_content);
    let mut html_content = String::new();
    html::push_html(&mut html_content, pulldown_parser);
    html_content
};
```