### PR TITLE
Make empty lists and ordered lists not at one interrupt tables

### DIFF
--- a/specs/table.txt
+++ b/specs/table.txt
@@ -735,3 +735,33 @@ Double escaping in link title
 <tr><td><a title="Example\|Link" href="https://example.org">Moo</a></td></tr>
 </tbody></table>
 ````````````````````````````````
+
+Blank list items and lists that don't start at one can interrupt tables.
+
+```````````````````````````````` example
+moo | moo
+----|----
+moo | moo
+*
+.
+<table><thead><tr><th>moo</th><th>moo</th></tr></thead><tbody>
+<tr><td>moo</td><td>moo</td></tr>
+</tbody></table>
+<ul>
+<li></li>
+</ul>
+````````````````````````````````
+
+```````````````````````````````` example
+moo | moo
+----|----
+moo | moo
+2.
+.
+<table><thead><tr><th>moo</th><th>moo</th></tr></thead><tbody>
+<tr><td>moo</td><td>moo</td></tr>
+</tbody></table>
+<ol start="2">
+<li></li>
+</ol>
+````````````````````````````````

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -1802,10 +1802,11 @@ fn scan_paragraph_interrupt_no_table<'tree>(
         || scan_blockquote_start(bytes).is_some()
         || scan_listitem(bytes).map_or(false, |(ix, delim, index, _)| {
             ! current_container ||
+            tree.is_in_table() ||
             // we don't allow interruption by either empty lists or
             // numbered lists starting at an index other than 1
             (delim == b'*' || delim == b'-' || delim == b'+' || index == 1)
-                && scan_blank_line(&bytes[ix..]).is_none()
+                && (scan_blank_line(&bytes[ix..]).is_none())
         })
         || bytes.starts_with(b"<")
             && (get_html_end_tag(&bytes[1..]).is_some() || starts_html_block_type_6(&bytes[1..]))

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2538,7 +2538,7 @@ fn regression_test_156() {
 
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_157() {
     let original = r##"`\!\"\#\$\%\&
@@ -2550,7 +2550,7 @@ fn regression_test_157() {
 
     test_markdown_html(original, expected, false, false, false);
 }
-    
+
 #[test]
 fn regression_test_158() {
     let original = r##"|

--- a/tests/suite/table.rs
+++ b/tests/suite/table.rs
@@ -593,3 +593,39 @@ fn table_test_26() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn table_test_27() {
+    let original = r##"moo | moo
+----|----
+moo | moo
+*
+"##;
+    let expected = r##"<table><thead><tr><th>moo</th><th>moo</th></tr></thead><tbody>
+<tr><td>moo</td><td>moo</td></tr>
+</tbody></table>
+<ul>
+<li></li>
+</ul>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn table_test_28() {
+    let original = r##"moo | moo
+----|----
+moo | moo
+2.
+"##;
+    let expected = r##"<table><thead><tr><th>moo</th><th>moo</th></tr></thead><tbody>
+<tr><td>moo</td><td>moo</td></tr>
+</tbody></table>
+<ol start="2">
+<li></li>
+</ol>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
Fixes #815

According to [babelmark 3](https://babelmark.github.io/?text=moo+%7C+moo%0A----%7C----%0Amoo+%7C+moo%0A*) almost every pipe table implementation has blank list items interrupt paragraphs, except

* cebe, which does what pulldown-cmark used to do
* the DFM, MD4C, and s9e cluster, which interrupts the table but doesn't make a list
