### PR TITLE
Allow footnote definitions to not be separated by blank lines

### DIFF
--- a/examples/parser-map-event-print.rs
+++ b/examples/parser-map-event-print.rs
@@ -1,15 +1,17 @@
-use pulldown_cmark::{Event, Parser, html};
+use pulldown_cmark::{html, Event, Parser};
 
 fn main() {
     let markdown_input = "# Example Heading\nExample paragraph with **lorem** _ipsum_ text.";
-    println!("\nParsing the following markdown string:\n{}\n", markdown_input);
+    println!(
+        "\nParsing the following markdown string:\n{}\n",
+        markdown_input
+    );
 
-    // Set up the parser. We can treat is as any other iterator. 
+    // Set up the parser. We can treat is as any other iterator.
     // For each event, we print its details, such as the tag or string.
     // This filter simply returns the same event without any changes;
     // you can compare the `event-filter` example which alters the output.
-    let parser = Parser::new(markdown_input)
-    .map(|event| {
+    let parser = Parser::new(markdown_input).map(|event| {
         match &event {
             Event::Start(tag) => println!("Start: {:?}", tag),
             Event::End(tag) => println!("End: {:?}", tag),

--- a/examples/parser-map-tag-print.rs
+++ b/examples/parser-map-tag-print.rs
@@ -19,7 +19,7 @@ fn main() {
         "```\n",
         "my code block\n",
         "```\n",
-        "\n",       
+        "\n",
         "*emphasis*\n",
         "**strong**\n",
         "~~strikethrough~~\n",
@@ -33,40 +33,57 @@ fn main() {
         "hello[^1]\n",
         "[^1]: my footnote\n",
     );
-    println!("\nParsing the following markdown string:\n{}\n", markdown_input);
+    println!(
+        "\nParsing the following markdown string:\n{}\n",
+        markdown_input
+    );
 
-    // Set up the parser. We can treat is as any other iterator. 
+    // Set up the parser. We can treat is as any other iterator.
     // For each event, we print its details, such as the tag or string.
     // This filter simply returns the same event without any changes;
     // you can compare the `event-filter` example which alters the output.
-    let parser = Parser::new_ext(markdown_input, Options::all())
-    .map(|event| {
+    let parser = Parser::new_ext(markdown_input, Options::all()).map(|event| {
         match &event {
-            Event::Start(tag) => {
-                match tag {
-                    Tag::Heading(heading_level, fragment_identifier, class_list) => println!("Heading heading_level: {} fragment identifier: {:?} classes: {:?}", heading_level, fragment_identifier, class_list),
-                    Tag::Paragraph => println!("Paragraph"),                       
-                    Tag::List(ordered_list_first_item_number) => println!("List ordered_list_first_item_number: {:?}", ordered_list_first_item_number),
-                    Tag::Item => println!("Item (this is a list item)"),
-                    Tag::Emphasis => println!("Emphasis (this is a span tag)"),
-                    Tag::Strong => println!("Strong (this is a span tag)"),
-                    Tag::Strikethrough => println!("Strikethrough (this is a span tag)"),
-                    Tag::BlockQuote => println!("BlockQuote"),
-                    Tag::CodeBlock(code_block_kind) => println!("CodeBlock code_block_kind: {:?}", code_block_kind),
-                    Tag::Link(link_type, url, title) => println!("Link link_type: {:?} url: {} title: {}", link_type, url, title),
-                    Tag::Image(link_type, url, title) => println!("Image link_type: {:?} url: {} title: {}", link_type, url, title),
-                    Tag::Table(column_text_alignment_list) => println!("Table column_text_alignment_list: {:?}", column_text_alignment_list),
-                    Tag::TableHead => println!("TableHead (contains TableRow tags"),
-                    Tag::TableRow => println!("TableRow (contains TableCell tags)"),
-                    Tag::TableCell => println!("TableCell (contains inline tags)"),
-                    Tag::FootnoteDefinition(label) => println!("FootnoteDefinition label: {}", label),
+            Event::Start(tag) => match tag {
+                Tag::Heading(heading_level, fragment_identifier, class_list) => println!(
+                    "Heading heading_level: {} fragment identifier: {:?} classes: {:?}",
+                    heading_level, fragment_identifier, class_list
+                ),
+                Tag::Paragraph => println!("Paragraph"),
+                Tag::List(ordered_list_first_item_number) => println!(
+                    "List ordered_list_first_item_number: {:?}",
+                    ordered_list_first_item_number
+                ),
+                Tag::Item => println!("Item (this is a list item)"),
+                Tag::Emphasis => println!("Emphasis (this is a span tag)"),
+                Tag::Strong => println!("Strong (this is a span tag)"),
+                Tag::Strikethrough => println!("Strikethrough (this is a span tag)"),
+                Tag::BlockQuote => println!("BlockQuote"),
+                Tag::CodeBlock(code_block_kind) => {
+                    println!("CodeBlock code_block_kind: {:?}", code_block_kind)
                 }
+                Tag::Link(link_type, url, title) => println!(
+                    "Link link_type: {:?} url: {} title: {}",
+                    link_type, url, title
+                ),
+                Tag::Image(link_type, url, title) => println!(
+                    "Image link_type: {:?} url: {} title: {}",
+                    link_type, url, title
+                ),
+                Tag::Table(column_text_alignment_list) => println!(
+                    "Table column_text_alignment_list: {:?}",
+                    column_text_alignment_list
+                ),
+                Tag::TableHead => println!("TableHead (contains TableRow tags"),
+                Tag::TableRow => println!("TableRow (contains TableCell tags)"),
+                Tag::TableCell => println!("TableCell (contains inline tags)"),
+                Tag::FootnoteDefinition(label) => println!("FootnoteDefinition label: {}", label),
             },
-            _ => ()
+            _ => (),
         };
         event
     });
-   
+
     let mut html_output = String::new();
     pulldown_cmark::html::push_html(&mut html_output, parser);
     println!("\nHTML output:\n{}\n", &html_output);

--- a/specs/footnotes.txt
+++ b/specs/footnotes.txt
@@ -137,17 +137,25 @@ Nested footnotes are considered poor style. [^a] [^xkcd]
 </div>
 ````````````````````````````````
 
-They do need one line between each other.
+They don't need one line between each other.
 
 ```````````````````````````````` example
 [^Doh] Ray Me Fa So La Te Do! [^1]
 
-[^Doh]: I know. Wrong Doe. And it won't render right.
+[^Doh]: I know. Wrong Doe. And it will render right.
 [^1]: Common for people practicing music.
 .
-<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p>
-<div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup>
-<p>I know. Wrong Doe. And it won't render right.
-<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p>
-</div>
+<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p> <div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup> <p>I know. Wrong Doe. And it will render right.</p></div><div class="footnote-definition" id="1"><sup class="footnote-definition-label">2</sup> <p>Common for people practicing music.</p></div>
+````````````````````````````````
+
+Second check for footnotes:
+
+```````````````````````````````` example
+[Reference to footnotes A[^1], B[^2] and C[^3].
+
+[^1]: Footnote A.
+[^2]: Footnote B.
+[^3]: Footnote C.
+.
+<p>[Reference to footnotes A<sup class="footnote-reference"><a href="#1">1</a></sup>, B<sup class="footnote-reference"><a href="#2">2</a></sup> and C<sup class="footnote-reference"><a href="#3">3</a></sup>.</p> <div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup> <p>Footnote A.</p></div><div class="footnote-definition" id="2"><sup class="footnote-definition-label">2</sup> <p>Footnote B.</p></div><div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup> <p>Footnote C.</p></div>
 ````````````````````````````````

--- a/tests/suite/footnotes.rs
+++ b/tests/suite/footnotes.rs
@@ -151,14 +151,24 @@ fn footnotes_test_7() {
 fn footnotes_test_8() {
     let original = r##"[^Doh] Ray Me Fa So La Te Do! [^1]
 
-[^Doh]: I know. Wrong Doe. And it won't render right.
+[^Doh]: I know. Wrong Doe. And it will render right.
 [^1]: Common for people practicing music.
 "##;
-    let expected = r##"<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p>
-<div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup>
-<p>I know. Wrong Doe. And it won't render right.
-<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p>
-</div>
+    let expected = r##"<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p> <div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup> <p>I know. Wrong Doe. And it will render right.</p></div><div class="footnote-definition" id="1"><sup class="footnote-definition-label">2</sup> <p>Common for people practicing music.</p></div>
+"##;
+
+    test_markdown_html(original, expected, false);
+}
+
+#[test]
+fn footnotes_test_9() {
+    let original = r##"[Reference to footnotes A[^1], B[^2] and C[^3].
+
+[^1]: Footnote A.
+[^2]: Footnote B.
+[^3]: Footnote C.
+"##;
+    let expected = r##"<p>[Reference to footnotes A<sup class="footnote-reference"><a href="#1">1</a></sup>, B<sup class="footnote-reference"><a href="#2">2</a></sup> and C<sup class="footnote-reference"><a href="#3">3</a></sup>.</p> <div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup> <p>Footnote A.</p></div><div class="footnote-definition" id="2"><sup class="footnote-definition-label">2</sup> <p>Footnote B.</p></div><div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup> <p>Footnote C.</p></div>
 "##;
 
     test_markdown_html(original, expected, false);


### PR DESCRIPTION
This is a change allowing to fix https://github.com/rust-lang/rust/issues/100638.

It's a bit strange that link definitions can follow each others but that footnote definitions can't so I think for consistency, allowing it would be more logical.

As for the code, it's not great as it forces to "look ahead" in case this is a footnote definition and then return and come back into `parse_block` to actually put this new footnote definition into the tree. If you have suggestions for improving it, it'd be very welcome! :)