### PR TITLE
Reject long decimal and hex entities, turn invalid ones into U+FFFD

### DIFF
--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -2204,3 +2204,14 @@ First ![^1][] Second
 <p>foo</p>
 </div>
 ````````````````````````````````
+
+ISSUE 826
+
+HTML entities can only have up to seven digits,
+or six hexits.
+
+```````````````````````````````` example
+&#00000000; &#x0000000;
+.
+<p>&amp;#00000000; &amp;#x0000000;</p>
+````````````````````````````````

--- a/specs/regression.txt
+++ b/specs/regression.txt
@@ -2215,3 +2215,12 @@ or six hexits.
 .
 <p>&amp;#00000000; &amp;#x0000000;</p>
 ````````````````````````````````
+
+&#5307530; is invalid unicode. As described in the spec,
+invalid unicode is replaced with the unknown U+FFFD.
+
+```````````````````````````````` example
+&#5307530;
+.
+<p>�</p>
+````````````````````````````````

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -792,9 +792,9 @@ fn parse_hex(bytes: &[u8], limit: usize) -> (usize, usize) {
 }
 
 fn char_from_codepoint(input: usize) -> Option<char> {
-    let mut codepoint = input.try_into().ok()?;
+    let codepoint = input.try_into().ok()?;
     if codepoint == 0 {
-        codepoint = 0xFFFD;
+        return None;
     }
     char::from_u32(codepoint)
 }
@@ -813,10 +813,8 @@ pub(crate) fn scan_entity(bytes: &[u8]) -> (usize, Option<CowStr<'static>>) {
         end += bytecount;
         return if bytecount == 0 || scan_ch(&bytes[end..], b';') == 0 {
             (0, None)
-        } else if let Some(c) = char_from_codepoint(codepoint) {
-            (end + 1, Some(c.into()))
         } else {
-            (0, None)
+            (end + 1, Some(char_from_codepoint(codepoint).unwrap_or('\u{FFFD}').into()))
         };
     }
     end += scan_while(&bytes[end..], is_ascii_alphanumeric);

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -715,7 +715,7 @@ pub(crate) fn scan_listitem(bytes: &[u8]) -> Option<(usize, u8, usize, usize)> {
     let (w, start) = match c {
         b'-' | b'+' | b'*' => (1, 0),
         b'0'..=b'9' => {
-            let (length, start) = parse_decimal(bytes);
+            let (length, start) = parse_decimal(bytes, 9);
             c = *bytes.get(length)?;
             if !(c == b'.' || c == b')') {
                 return None;
@@ -743,9 +743,10 @@ pub(crate) fn scan_listitem(bytes: &[u8]) -> Option<(usize, u8, usize, usize)> {
 }
 
 // returns (number of bytes, parsed decimal)
-fn parse_decimal(bytes: &[u8]) -> (usize, usize) {
+fn parse_decimal(bytes: &[u8], limit: usize) -> (usize, usize) {
     match bytes
         .iter()
+        .take(limit)
         .take_while(|&&b| is_digit(b))
         .try_fold((0, 0usize), |(count, acc), c| {
             let digit = usize::from(c - b'0');
@@ -763,8 +764,8 @@ fn parse_decimal(bytes: &[u8]) -> (usize, usize) {
 }
 
 // returns (number of bytes, parsed hex)
-fn parse_hex(bytes: &[u8]) -> (usize, usize) {
-    match bytes.iter().try_fold((0, 0usize), |(count, acc), c| {
+fn parse_hex(bytes: &[u8], limit: usize) -> (usize, usize) {
+    match bytes.iter().take(limit).try_fold((0, 0usize), |(count, acc), c| {
         let mut c = *c;
         let digit = if c >= b'0' && c <= b'9' {
             usize::from(c - b'0')
@@ -805,9 +806,9 @@ pub(crate) fn scan_entity(bytes: &[u8]) -> (usize, Option<CowStr<'static>>) {
         end += 1;
         let (bytecount, codepoint) = if end < bytes.len() && bytes[end] | 0x20 == b'x' {
             end += 1;
-            parse_hex(&bytes[end..])
+            parse_hex(&bytes[end..], 6)
         } else {
-            parse_decimal(&bytes[end..])
+            parse_decimal(&bytes[end..], 7)
         };
         end += bytecount;
         return if bytecount == 0 || scan_ch(&bytes[end..], b';') == 0 {

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2571,7 +2571,7 @@ fn regression_test_159() {
 
     test_markdown_html(original, expected, false, false, false);
 }
-  
+
 #[test]
 fn regression_test_160() {
     let original = r##"![^1]
@@ -2597,6 +2597,16 @@ fn regression_test_161() {
 <div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup>
 <p>foo</p>
 </div>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn regression_test_162() {
+    let original = r##"&#00000000; &#x0000000;
+"##;
+    let expected = r##"<p>&amp;#00000000; &amp;#x0000000;</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);

--- a/tests/suite/regression.rs
+++ b/tests/suite/regression.rs
@@ -2611,3 +2611,13 @@ fn regression_test_162() {
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn regression_test_163() {
+    let original = r##"&#5307530;
+"##;
+    let expected = r##"<p>�</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}


### PR DESCRIPTION
Fixes #826 