### PR TITLE
Set range end to Paragraph if returned early because of footnote definition

### DIFF
--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -321,6 +321,7 @@ impl<'a, 'b> FirstPass<'a, 'b> {
         let mut ix = start_ix;
         loop {
             if self.options.contains(Options::ENABLE_FOOTNOTES) && self.get_footnote(ix).is_some() {
+                self.tree[node_ix].item.end = if ix > start_ix { ix - 1 } else { start_ix };
                 self.tree.pop();
                 if let Some(node_ix) = self.tree.peek_up() {
                     if let ItemBody::FootnoteDefinition(..) = self.tree[node_ix].item.body {


### PR DESCRIPTION
My deepest apologies, I didn't notice but the end range was not filled and it panicked when running rustdoc on the code I used for the test. I fixed it and added a regression test to ensure the range is always filled as expected.

Can you yank the `0.9.4` version and release the `0.9.5` please? Again, I'm very sorry for not noticing the bug earlier on.