### PR TITLE
Backport footnote handling without needing blank lines between them for old footnote format

### DIFF
--- a/specs/old_footnotes.txt
+++ b/specs/old_footnotes.txt
@@ -142,12 +142,21 @@ They do need one line between each other.
 ```````````````````````````````` example_old_footnotes
 [^Doh] Ray Me Fa So La Te Do! [^1]
 
-[^Doh]: I know. Wrong Doe. And it won't render right.
+[^Doh]: I know. Wrong Doe. And it will render right.
 [^1]: Common for people practicing music.
 .
-<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p>
-<div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup>
-<p>I know. Wrong Doe. And it won't render right.
-<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p>
-</div>
+<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p><div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup><p>I know. Wrong Doe. And it will render right.
+<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p></div>
+````````````````````````````````
+
+Second check for footnotes:
+
+```````````````````````````````` example
+[Reference to footnotes A[^1], B[^2] and C[^3].
+
+[^1]: Footnote A.
+[^2]: Footnote B.
+[^3]: Footnote C.
+.
+<p>[Reference to footnotes A<sup class="footnote-reference"><a href="#1">1</a></sup>, B<sup class="footnote-reference"><a href="#2">2</a></sup> and C<sup class="footnote-reference"><a href="#3">3</a></sup>.</p><div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup><p>Footnote A.</p></div><div class="footnote-definition" id="2"><sup class="footnote-definition-label">2</sup><p>Footnote B.</p></div><div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup><p>Footnote C.</p></div>
 ````````````````````````````````

--- a/src/firstpass.rs
+++ b/src/firstpass.rs
@@ -101,7 +101,9 @@ impl<'a, 'b> FirstPass<'a, 'b> {
 
         // Process new containers
         loop {
-            if self.options.has_gfm_footnotes() {
+            if self.options.has_gfm_footnotes()
+                || self.options.contains(Options::ENABLE_OLD_FOOTNOTES)
+            {
                 // Footnote definitions of the form
                 // [^bar]:
                 //     * anything really
@@ -1363,7 +1365,12 @@ impl<'a, 'b> FirstPass<'a, 'b> {
             let (line_ix, line_brk) = self.parse_line(ix, None, TableParseMode::Disabled);
             ix = line_ix;
             // Backslash at end is actually hard line break
-            if let Some(Item { start, end, body: ItemBody::HardBreak(true) }) = line_brk {
+            if let Some(Item {
+                start,
+                end,
+                body: ItemBody::HardBreak(true),
+            }) = line_brk
+            {
                 self.tree.append_text(start, end, false);
             }
             (ix, ix, None)

--- a/tests/suite/old_footnotes.rs
+++ b/tests/suite/old_footnotes.rs
@@ -151,15 +151,26 @@ fn old_footnotes_test_7() {
 fn old_footnotes_test_8() {
     let original = r##"[^Doh] Ray Me Fa So La Te Do! [^1]
 
-[^Doh]: I know. Wrong Doe. And it won't render right.
+[^Doh]: I know. Wrong Doe. And it will render right.
 [^1]: Common for people practicing music.
 "##;
-    let expected = r##"<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p>
-<div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup>
-<p>I know. Wrong Doe. And it won't render right.
-<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p>
-</div>
+    let expected = r##"<p><sup class="footnote-reference"><a href="#Doh">1</a></sup> Ray Me Fa So La Te Do! <sup class="footnote-reference"><a href="#1">2</a></sup></p><div class="footnote-definition" id="Doh"><sup class="footnote-definition-label">1</sup><p>I know. Wrong Doe. And it will render right.
+<sup class="footnote-reference"><a href="#1">2</a></sup>: Common for people practicing music.</p></div>
 "##;
 
     test_markdown_html(original, expected, false, false, true);
+}
+
+#[test]
+fn old_footnotes_test_9() {
+    let original = r##"[Reference to footnotes A[^1], B[^2] and C[^3].
+
+[^1]: Footnote A.
+[^2]: Footnote B.
+[^3]: Footnote C.
+"##;
+    let expected = r##"<p>[Reference to footnotes A<sup class="footnote-reference"><a href="#1">1</a></sup>, B<sup class="footnote-reference"><a href="#2">2</a></sup> and C<sup class="footnote-reference"><a href="#3">3</a></sup>.</p><div class="footnote-definition" id="1"><sup class="footnote-definition-label">1</sup><p>Footnote A.</p></div><div class="footnote-definition" id="2"><sup class="footnote-definition-label">2</sup><p>Footnote B.</p></div><div class="footnote-definition" id="3"><sup class="footnote-definition-label">3</sup><p>Footnote C.</p></div>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
 }


### PR DESCRIPTION
Backport of #825 for old footnote format as discussed in https://github.com/raphlinus/pulldown-cmark/pull/831.