### PR TITLE
Implement missing cell cutoff to stop quadratic results

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -4,6 +4,25 @@ mod to_html {
     use criterion::{BenchmarkId, Criterion, Throughput};
     use pulldown_cmark::{html, Options, Parser};
 
+    pub fn pathological_missing_table_cells(c: &mut Criterion) {
+        let mut group = c.benchmark_group("    pub fn pathological_missing_table_cells(c: &mut Criterion) {
+            ");
+        let mut buf = String::new();
+        for i in 1..20 {
+            buf.clear();
+            buf.push_str(&"|x".repeat(i * 100));
+            buf.push('\n');
+            buf.push_str(&"|-".repeat(i * 100));
+            buf.push('\n');
+            buf.push_str(&"|x\n".repeat(i * 100));
+            group.throughput(Throughput::Bytes(buf.len() as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(i), &buf, |b, buf| {
+                b.iter(|| render_html(buf, Options::ENABLE_TABLES));
+            });
+        }
+        group.finish();
+    }
+
     pub fn pathological_codeblocks1(c: &mut Criterion) {
         let mut group = c.benchmark_group("pathological_codeblocks1");
         let mut buf = String::new();
@@ -45,6 +64,7 @@ mod to_html {
 
 criterion_group!(
     benches,
+    to_html::pathological_missing_table_cells,
     to_html::pathological_codeblocks1,
     to_html::advanced_pathological_codeblocks
 );


### PR DESCRIPTION
Fixes #832

Benchmarks:

- before: https://notriddle.com/benchmark-html-out/pulldown-cmark-table-old/report/index.html

  ![a line chart, that's kinda wobbly but seems to curve upward, topping around 160ms](https://github.com/raphlinus/pulldown-cmark/assets/1593513/27226353-03a3-4284-9544-cb7c3e7cc34c)

- after: https://notriddle.com/benchmark-html-out/pulldown-cmark-table-new/report/index.html

  ![a line chart that rapidly hits a peak around 7.5ms and stays there](https://github.com/raphlinus/pulldown-cmark/assets/1593513/b663c6b1-a5ea-4953-990e-e1190aa80efd)
